### PR TITLE
Fix memory issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 setup(
     name="whisperx",
     py_modules=["whisperx"],
-    version="1.0",
+    version="1.1",
     description="Time-Accurate Automatic Speech Recognition using Whisper.",
     readme="README.md",
     python_requires=">=3.7",


### PR DESCRIPTION
Ref: #89 

This PR fixes some issues with the alignment step.
The alignment model would be loaded too early, resulting in too much CUDA memory usage when both it and e.g. Whisper was loaded.
The solution was to load the alignment model lazily, and garbage collect Whisper and the VAD pipeline before doing any alignment work.

Added new flag `--gc_memory` which will try to gc unusued models and clean CUDA cache, off by default to keep backwards compatibility.