### PR TITLE
GPU acceleration when using VAD filters

### DIFF
--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -645,9 +645,12 @@ def cli():
         if hf_token is None:
             print("Warning, no huggingface token used, needs to be saved in environment variable, otherwise will throw error loading VAD model...")
         from pyannote.audio import Inference
-        vad_pipeline = Inference("pyannote/segmentation",
-                            pre_aggregation_hook=lambda segmentation: segmentation,
-                            use_auth_token=hf_token)
+        vad_pipeline = Inference(
+            "pyannote/segmentation",
+            pre_aggregation_hook=lambda segmentation: segmentation,
+            use_auth_token=hf_token,
+            device=torch.device(device),
+        )
 
     diarize_pipeline = None
     if diarize:


### PR DESCRIPTION
This PR allows for GPU acceleration when using VAD filters.

whisperX's VAD filter always infers on CPU.
In whisperx/transcribe.py, `pyannote.audio.Inference` is not passed `device` argument.
You can see the devices used for inference as follows:

```
$ python
Python 3.10.7 (main, Nov 13 2022, 02:27:45) [GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>> import torch
>> torch.cuda.is_available()
True

>>> from pyannote.audio import Inference
>>> vad_pipeline = Inference("pyannote/segmentation")
>>> vad_pipeline.model.device
device(type='cpu')
```

When tested on a 22 minutes and 20 seconds audio file, the process took 4 minutes and 27 seconds before the modification and 1 minute and 49 seconds after the modification. The processing time was reduced to less than half.