### PR TITLE
Added Python 3.7 compatibility

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -243,9 +243,8 @@ def align(
             if "seg-text" not in segment:
                 segment["seg-text"] = [transcription]
                 
-            v = 0
             seg_lens = [0] + [len(x) for x in segment["seg-text"]]
-            seg_lens_cumsum = [v := v + n for n in seg_lens]
+            seg_lens_cumsum = list(np.cumsum(seg_lens))
             sub_seg_idx = 0
 
             wdx = 0


### PR DESCRIPTION
- removed use of walrus operator in favor of `np.cumsum`
- fixes #92 

Seems to work fine, tested the examples from the readme on Docker image `python:3.7-slim-bullseye` and the results are identical.