### PR TITLE
fix: force soundfile version update for mp3 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ numpy
 torch
 torchaudio
 tqdm
-soundfile
 more-itertools
 transformers>=4.19.0
 ffmpeg-python==0.2.0
 pyannote.audio
+soundfile>=0.12.0


### PR DESCRIPTION
python-soundfile now supports mp3 files since [v0.12.0](https://github.com/bastibe/python-soundfile/releases/tag/0.12.0.) 

closes #41