### PR TITLE
Added a function for VAD-segments to handle mp3 files, numpy arrays and tensors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ torch
 torchaudio
 tqdm
 more-itertools
-soundfile
 transformers>=4.19.0
 ffmpeg-python==0.2.0
 pyannote.audio
+soundfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ torch
 torchaudio
 tqdm
 more-itertools
+soundfile>=0.12.0
 transformers>=4.19.0
 ffmpeg-python==0.2.0
 pyannote.audio
-soundfile>=0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ torch
 torchaudio
 tqdm
 more-itertools
-soundfile>=0.12.0
+soundfile
 transformers>=4.19.0
 ffmpeg-python==0.2.0
 pyannote.audio

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -37,6 +37,7 @@ DEFAULT_ALIGN_MODELS_HF = {
     "fa": "jonatasgrosman/wav2vec2-large-xlsr-53-persian",
     "el": "jonatasgrosman/wav2vec2-large-xlsr-53-greek",
     "tr": "mpoyraz/wav2vec2-xls-r-300m-cv7-turkish",
+    "da": "saattrupdan/wav2vec2-xls-r-300m-ftspeech"
 }
 
 

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -36,8 +36,7 @@ DEFAULT_ALIGN_MODELS_HF = {
     "fi": "jonatasgrosman/wav2vec2-large-xlsr-53-finnish",
     "fa": "jonatasgrosman/wav2vec2-large-xlsr-53-persian",
     "el": "jonatasgrosman/wav2vec2-large-xlsr-53-greek",
-    "tr": "mpoyraz/wav2vec2-xls-r-300m-cv7-turkish",
-    "da": "saattrupdan/wav2vec2-xls-r-300m-ftspeech"
+    "tr": "mpoyraz/wav2vec2-xls-r-300m-cv7-turkish"
 }
 
 

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -339,8 +339,6 @@ def transcribe_with_vad(
     output = {"segments": []}
 
     vad_segments = get_vad_segments(audio, vad_pipeline)
-    # merge segments to approx 30s inputs to make whisper most appropraite
-    vad_segments = merge_chunks(vad_segments)
 
     for sdx, seg_t in enumerate(vad_segments):
         if verbose:
@@ -386,8 +384,6 @@ def transcribe_with_vad_parallel(
         mel = log_mel_spectrogram(audio)
 
     vad_segments = get_vad_segments(audio, vad_pipeline)
-    # merge segments to approx 30s inputs to make whisper most appropraite
-    vad_segments = merge_chunks(vad_segments)
 
     ################################
     ### START of parallelization ###

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -303,6 +303,13 @@ def merge_chunks(segments, chunk_size=CHUNK_LENGTH):
 def get_vad_segments(audio:Union[str, np.ndarray, torch.Tensor], vad_pipeline):
     """
     Get VAD segments
+
+    Args:
+        audio (Union[str, np.ndarray, torch.Tensor]): audio file path or audio waveform
+        vad_pipeline (Pipeline): VAD pipeline
+
+    Returns:
+        List[Dict]: list of merged VAD segments
     """
     if isinstance(audio, str):
         if audio.endswith(".mp3"):
@@ -311,10 +318,15 @@ def get_vad_segments(audio:Union[str, np.ndarray, torch.Tensor], vad_pipeline):
             vad_segments = vad_pipeline({"waveform" : wave,  "sample_rate" : SAMPLE_RATE})
         else:
             vad_segments = vad_pipeline(audio)
-    elif isinstance(audio, np.ndarray) or isinstance(audio, torch.Tensor):
+    elif isinstance(audio, np.ndarray):
         if audio.ndim == 1:
             wave = torch.tensor((audio, audio))
         vad_segments = vad_pipeline({"waveform" : wave,  "sample_rate" : SAMPLE_RATE})
+    elif isinstance(audio, torch.Tensor):
+        if audio.ndim == 1:
+            wave = torch.stack((audio, audio))
+        vad_segments = vad_pipeline({"waveform" : wave,  "sample_rate" : SAMPLE_RATE})
+    
     # merge segments to approx 30s inputs to make whisper most appropraite
     vad_segments = merge_chunks(vad_segments)
     return vad_segments

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -362,6 +362,9 @@ def transcribe_with_vad_parallel(
     """
 
     audio_wave = load_audio(audio)
+
+    # We get mono channel back from load audio. Vad need 2 channels
+    audio_wave = torch.tensor((audio_wave, audio_wave))
     
     vad_segments = vad_pipeline({"waveform" : audio_wave,  "sample_rate" : SAMPLE_RATE})
     # merge segments to approx 30s inputs to make whisper most appropraite

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -351,7 +351,7 @@ def transcribe_with_vad(
 
 def transcribe_with_vad_parallel(
     model: "Whisper",
-    audio: Union[str, np.ndarray, torch.Tensor],
+    audio: str,
     vad_pipeline,
     mel = None,
     verbose: Optional[bool] = None,
@@ -362,10 +362,12 @@ def transcribe_with_vad_parallel(
     Transcribe per VAD segment
     """
 
+    audio_wave = load_audio(audio)
+
     if mel is None:
-        mel = log_mel_spectrogram(audio)
+        mel = log_mel_spectrogram(audio_wave)
     
-    vad_segments = vad_pipeline(audio)
+    vad_segments = vad_pipeline({"waveform" : audio_wave,  "sample_rate" : SAMPLE_RATE})
     # merge segments to approx 30s inputs to make whisper most appropraite
     vad_segments = merge_chunks(vad_segments)
 

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -353,7 +353,6 @@ def transcribe_with_vad_parallel(
     model: "Whisper",
     audio: str,
     vad_pipeline,
-    mel = None,
     verbose: Optional[bool] = None,
     batch_size = -1,
     **kwargs
@@ -363,9 +362,6 @@ def transcribe_with_vad_parallel(
     """
 
     audio_wave = load_audio(audio)
-
-    if mel is None:
-        mel = log_mel_spectrogram(audio_wave)
     
     vad_segments = vad_pipeline({"waveform" : audio_wave,  "sample_rate" : SAMPLE_RATE})
     # merge segments to approx 30s inputs to make whisper most appropraite

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -353,6 +353,7 @@ def transcribe_with_vad_parallel(
     model: "Whisper",
     audio: str,
     vad_pipeline,
+    mel = None,
     verbose: Optional[bool] = None,
     batch_size = -1,
     **kwargs

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -381,7 +381,7 @@ def transcribe_with_vad(
 
 def transcribe_with_vad_parallel(
     model: "Whisper",
-    audio: str,
+    audio: Union[str, np.ndarray, torch.Tensor],
     vad_pipeline,
     mel = None,
     verbose: Optional[bool] = None,

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -363,6 +363,9 @@ def transcribe_with_vad_parallel(
 
     audio_wave = load_audio(audio)
 
+    if mel is None:
+        mel = log_mel_spectrogram(audio_wave)
+
     # We get mono channel back from load audio. Vad need 2 channels
     audio_wave = torch.tensor((audio_wave, audio_wave))
     


### PR DESCRIPTION
I found that the function would let you parse numpy arrays and tensors. The VAD pipeline does however not support this, by just parsing, since you need to parse it as a mapping with the sample rate. 

As of now  you can't parse a mp3 file to the vad pipeline. I fixed this by reading the file with whisper audio_load and then converting it to stereo. This is not a pretty solution, but it seems to work quite well. 