### PR TITLE
Add support for Faster-Whisper with CTranslate2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ transformers>=4.19.0
 ffmpeg-python==0.2.0
 pyannote.audio
 soundfile
+faster-whisper[conversion]

--- a/whisperx/__init__.py
+++ b/whisperx/__init__.py
@@ -27,6 +27,30 @@ _MODELS = {
     "large": "https://openaipublic.azureedge.net/main/whisper/models/81f7c96c852ee8fc832187b0132e569d6c3065a3252ed18e56effd0b6a73e524/large-v2.pt",
 }
 
+OPENAI_WHISPER_HUGGINGFACE_MODELS = [
+    "openai/whisper-tiny-en",
+    "openai/whisper-tiny",
+    "openai/whisper-base-en",
+    "openai/whisper-base",
+    "openai/whisper-small-en",
+    "openai/whisper-small",
+    "openai/whisper-medium-en",
+    "openai/whisper-medium",
+    "openai/whisper-large-v1",
+    "openai/whisper-large-v2",
+    "openai/whisper-large",
+]
+
+
+def convert_whisper_to_ct2_model(model_name: str, output_dir: str, quantization: str):
+    """Converts a HuggingFace model to a CTranslate2 model.
+    Ref: https://github.com/guillaumekln/faster-whisper/#model-conversion
+    """
+    print('Converting model to CTranslate2 model...')
+    os.system(f'ct2-transformers-converter --model {model_name} --output_dir {output_dir} \
+    --copy_files tokenizer.json --quantization {quantization}')
+    pass
+
 
 def _download(url: str, root: str, in_memory: bool) -> Union[bytes, str]:
     os.makedirs(root, exist_ok=True)
@@ -64,7 +88,7 @@ def _download(url: str, root: str, in_memory: bool) -> Union[bytes, str]:
 
 def available_models() -> List[str]:
     """Returns the names of available models"""
-    return list(_MODELS.keys())
+    return list(_MODELS.keys()) + OPENAI_WHISPER_HUGGINGFACE_MODELS
 
 
 def load_model(name: str, device: Optional[Union[str, torch.device]] = None, download_root: str = None, in_memory: bool = False) -> Whisper:

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -574,7 +574,7 @@ def cli():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("audio", nargs="+", type=str, help="audio file(s) to transcribe")
     parser.add_argument("--model", default="small", choices=available_models(), help="name of the Whisper model to use")
-    parser.add_argument("--model_dir", type=str, default=None, help="the path to save model files; uses ~/.cache/whisper by default")
+    parser.add_argument("--model_dir", type=str, default='~/.cache/whisper', help="the path to save model files; uses ~/.cache/whisper by default")
     parser.add_argument("--faster_whisper", action="store_true", default=False, help="Use Faster-Whisper model rather than original Whisper from OpenAI")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu", help="device to use for PyTorch inference")
     parser.add_argument("--faster_whisper_quantization", type=str, default='float16', help="Quantization to use for Faster-Whisper model. See supported list in CTranslate2.")


### PR DESCRIPTION
Implementing #121 .

Adding support for [Faster-Whisper](https://github.com/guillaumekln/faster-whisper) which changed inference engine to `CTranslate2`. 

This change shall 

- Massive accelerate Whisper on GPU
- Make low-VRAM inference possible (for not super ancient GPUs with `float16` support)
- Made pure CPU inference viable speed-wise (with `int8` for Whisper, and CPU inference on VAD pipeline with Silero VAD waiting to be merged in #146 )

Also address:

- https://github.com/guillaumekln/faster-whisper/issues/39
- https://github.com/openai/whisper/discussions/29#discussioncomment-3726710

CC: @lucasbr15 @arnavmehta7 @acul3 @sailordiary
