### PR TITLE
Fix Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ more-itertools
 transformers>=4.19.0
 ffmpeg-python==0.2.0
 pyannote.audio
-whisper
+openai-whisper


### PR DESCRIPTION
WhisperX is downloading the PyPi package [whisper](https://pypi.org/project/whisper/) instead of [openai-whisper](https://pypi.org/project/openai-whisper/), which results in an error