### PR TITLE
Remove hyphen from dict keys

### DIFF
--- a/whisperx/diarize.py
+++ b/whisperx/diarize.py
@@ -19,7 +19,7 @@ class DiarizationPipeline:
 
 def assign_word_speakers(diarize_df, result_segments, fill_nearest=False):
     for seg in result_segments:
-        wdf = seg['word-segments']
+        wdf = seg['word_segments_df']
         if len(wdf['start'].dropna()) == 0:
             wdf['start'] = seg['start']
             wdf['end'] = seg['end']
@@ -40,7 +40,7 @@ def assign_word_speakers(diarize_df, result_segments, fill_nearest=False):
             else:
                 speaker = None
             speakers.append(speaker)
-        seg['word-segments']['speaker'] = speakers
+        seg['word_segments_df']['speaker'] = speakers
 
         speaker_count = pd.Series(speakers).value_counts()
         if len(speaker_count) == 0:
@@ -51,7 +51,7 @@ def assign_word_speakers(diarize_df, result_segments, fill_nearest=False):
     # create word level segments for .srt
     word_seg = []
     for seg in result_segments:
-        wseg = pd.DataFrame(seg["word-segments"])
+        wseg = pd.DataFrame(seg["word_segments_df"])
         for wdx, wrow in wseg.iterrows():
             if wrow["start"] is not None:
                 speaker = wrow['speaker']
@@ -61,7 +61,7 @@ def assign_word_speakers(diarize_df, result_segments, fill_nearest=False):
                     {
                         "start": wrow["start"],
                         "end": wrow["end"],
-                        "text": f"[{speaker}]: " + seg["text"][int(wrow["segment-text-start"]):int(wrow["segment-text-end"])]
+                        "text": f"[{speaker}]: " + seg["text"][int(wrow["segment_text_start"]):int(wrow["segment_text_end"])]
                     }
                 )
 

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -206,8 +206,8 @@ def cli():
         # Remove pandas dataframes from result so that
         # we can serialize the result with json
         for seg in result["segments"]:
-            seg.pop("word-segments", None)
-            seg.pop("char-segments", None)
+            seg.pop("word_segments_df", None)
+            seg.pop("char_segments_df", None)
 
         writer(result, audio_path, writer_args)
 


### PR DESCRIPTION
Substitutes every hyphen in a dictionary key with an underscore.
Why is this needed, isn't it just a question of code style? Hyphen is a reserved character and as such indexing with it will not work. This is usually not an issue as one can simply take quotation marks, but this is not always possible. This problem occurred to me when I was creating `TypedDict` classes out of the `word_segments` dictionaries.
To be precise, the following code failed
```
class SingleWordSegment(TypedDict):
    start: float
    end: float
    text: str
    word-segments: str # this is not a str, just as a dummy
    char-segments: str # this is not a str, just as a dummy
```
Neither escaping nor quotation marks are possible in such a case as `TypedDict` requires a Python identifier. The only way to fix this is removing the hyphen, this PR achieves it.