### PR TITLE
Don't crash when the returned text contains only numbers or symbols

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -300,7 +300,20 @@ def align(
         # reset prev_t2 due to drifting issues
         if not segment_align_success:
             prev_t2 = 0
+
+            if "seg-text" not in segment:
+                segment["seg-text"] = [segment["text"]]
+
+            for cdx, char in enumerate(segment["text"] + " "):
+                char_segments_arr["char"].append(char)
+                char_segments_arr["start"].append(float('nan'))
+                char_segments_arr["end"].append(float('nan'))
+                char_segments_arr["score"].append(float('nan'))
+                char_segments_arr["word-idx"].append(0)
+                char_segments_arr["segment-idx"].append(0)
+                char_segments_arr["subsegment-idx"].append(0)
         
+
     char_segments_arr = pd.DataFrame(char_segments_arr)
     not_space = char_segments_arr["char"] != " "
 


### PR DESCRIPTION
When the audio transcription results only in numbers, dates or symbols then whisperX crashes while manipulating the (unexpectedly empty) data frames. This change adds the original text to the segments array so processing can continue.

Possibly fixes #98 and #176.
Not sure if it's the best way to do it, but it seems to work.