### PR TITLE
Add war2vec model for Vietnamese

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -42,6 +42,7 @@ DEFAULT_ALIGN_MODELS_HF = {
     "tr": "mpoyraz/wav2vec2-xls-r-300m-cv7-turkish",
     "da": "saattrupdan/wav2vec2-xls-r-300m-ftspeech",
     "he": "imvladikon/wav2vec2-xls-r-300m-hebrew",
+    "vi": 'nguyenvulebinh/wav2vec2-base-vi'
 }
 
 


### PR DESCRIPTION
Added default model for Vietnamese.
Because I use Google Colab I added the model https://huggingface.co/nguyenvulebinh/wav2vec2-base-vi and it works pretty well.