### PR TITLE
Add Audacity export

### DIFF
--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -26,7 +26,7 @@ def cli():
     parser.add_argument("--compute_type", default="float16", type=str, choices=["float16", "float32", "int8"], help="compute type for computation")
 
     parser.add_argument("--output_dir", "-o", type=str, default=".", help="directory to save the outputs")
-    parser.add_argument("--output_format", "-f", type=str, default="all", choices=["all", "srt", "vtt", "txt", "tsv", "json"], help="format of the output file; if not specified, all available formats will be produced")
+    parser.add_argument("--output_format", "-f", type=str, default="all", choices=["all", "srt", "vtt", "txt", "tsv", "json", "aud"], help="format of the output file; if not specified, all available formats will be produced")
     parser.add_argument("--verbose", type=str2bool, default=True, help="whether to print out the progress and debug messages")
 
     parser.add_argument("--task", type=str, default="transcribe", choices=["transcribe", "translate"], help="whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate')")

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -365,6 +365,28 @@ class WriteTSV(ResultWriter):
             print(round(1000 * segment["end"]), file=file, end="\t")
             print(segment["text"].strip().replace("\t", " "), file=file, flush=True)
 
+class WriteAudacity(ResultWriter):
+    """
+    Write a transcript to a text file that audacity can import as labels.
+    The extension used is "aud" to distinguish it from the txt file produced by WriteTXT.
+    Yet this is not an audacity project but only a label file!
+    
+    Please note : Audacity uses seconds in timestamps not ms! 
+    Also there is no header expected.
+
+    If speaker is provided it is prepended to the text between double square brackets [[]].
+    """
+
+    extension: str = "aud"    
+
+    def write_result(self, result: dict, file: TextIO, options: dict):
+        ARROW = "	"
+        for segment in result["segments"]:
+            print(segment["start"], file=file, end=ARROW)
+            print(segment["end"], file=file, end=ARROW)
+            print( ( ("[[" + segment["speaker"] + "]]") if "speaker" in segment else "") + segment["text"].strip().replace("\t", " "), file=file, flush=True)
+
+            
 
 class WriteJSON(ResultWriter):
     extension: str = "json"
@@ -377,6 +399,7 @@ def get_writer(
     output_format: str, output_dir: str
 ) -> Callable[[dict, TextIO, dict], None]:
     writers = {
+        "aud": WriteAudacity,
         "txt": WriteTXT,
         "vtt": WriteVTT,
         "srt": WriteSRT,

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -399,12 +399,14 @@ def get_writer(
     output_format: str, output_dir: str
 ) -> Callable[[dict, TextIO, dict], None]:
     writers = {
-        "aud": WriteAudacity,
         "txt": WriteTXT,
         "vtt": WriteVTT,
         "srt": WriteSRT,
         "tsv": WriteTSV,
         "json": WriteJSON,
+    }
+    optional_writers = {
+        "aud": WriteAudacity,
     }
 
     if output_format == "all":
@@ -416,6 +418,8 @@ def get_writer(
 
         return write_all
 
+    if output_format in optional_writers:
+        return optional_writers[output_format](output_dir)
     return writers[output_format](output_dir)
 
 def interpolate_nans(x, method='nearest'):


### PR DESCRIPTION
Hi,

I wanted to check if the transcript produced by WhisperX had improved for French compared to the first time I tested it. And it has ... tremendously! This works really great. 

So I needed to check it in Audacity, that's why I made this export and I propose it now to the community. 

This exports the transcript to a text file that can be directly imported in Audacity as label file. This is useful to visually check the transcript-audio alignment.

To use it, fire up Audacity, then do "Import Labels" with this file.

![WhisperX_Audacity2](https://github.com/m-bain/whisperX/assets/91517923/3bb19b96-e55a-44ca-9b2f-38ae3f21ff05)






