### PR TITLE
adding link to Replicate demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ print(diarize_segments)
 print(result["segments"]) # segments are now assigned speaker IDs
 ```
 
+## Demos 🚀
+
+[![Replicate](https://replicate.com/daanelson/whisperx/badge)](https://replicate.com/daanelson/whisperx) 
+
+If you don't have access to your own GPUs, use the link above to try out WhisperX. 
 
 <h2 align="left" id="whisper-mod">Technical Details 👷‍♂️</h2>
 


### PR DESCRIPTION
Hey @m-bain, this is some really fantastic work; the performance you've been able to get out of Whisper is incredible. 

I've put a demo of [WhisperX up on Replicate](https://replicate.com/daanelson/whisperx); it's under my name at the moment but lmk if you're interested and I can transfer it to you. This PR adds a link to the demo on Replicate - can change the wording if you'd like. 

Happy to also add the [code it uses](https://github.com/daanelson/cog-whisperx) which automatically containerizes WhisperX if you're interested - I know some folks find that useful but also understand wanting to keep your repo uncluttered. 