### PR TITLE
feat: return avg_logprobs from faster_whisper

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -10,8 +10,9 @@ from transformers import Pipeline
 from transformers.pipelines.pt_utils import PipelineIterator
 
 from .audio import N_SAMPLES, SAMPLE_RATE, load_audio, log_mel_spectrogram
+from .types import SingleSegment, TranscriptionResult
 from .vad import load_vad_model, merge_chunks
-from .types import TranscriptionResult, SingleSegment
+
 
 def find_numeral_symbol_tokens(tokenizer):
     numeral_symbol_tokens = []
@@ -138,24 +139,35 @@ class WhisperModel(faster_whisper.WhisperModel):
         result = self.model.generate(
                 encoder_output,
                 [prompt] * batch_size,
+                return_scores=True,
                 length_penalty=options.length_penalty,
                 max_length=self.max_length,
                 suppress_blank=options.suppress_blank,
                 suppress_tokens=options.suppress_tokens,
             )
-
-        tokens_batch = [x.sequences_ids[0] for x in result]
-
-        def decode_batch(tokens: List[List[int]]) -> str:
+    
+        avg_logprobs = []
+        tokens_batch = []
+        for result in result:
+            tokens = result.sequences_ids[0]
+            tokens_batch.append(tokens)
+    
+            # Calculate average log probability.
+            seq_len = len(tokens)
+            cum_logprob = result.scores[0] * (seq_len**options.length_penalty)
+            avg_logprob = cum_logprob / (seq_len + 1)
+            avg_logprobs.append(avg_logprob)
+    
+        def decode_batch(tokens: List[List[int]]) -> List[str]:
             res = []
             for tk in tokens:
                 res.append([token for token in tk if token < tokenizer.eot])
-            # text_tokens = [token for token in tokens if token < self.eot]
             return tokenizer.tokenizer.decode_batch(res)
 
         text = decode_batch(tokens_batch)
 
-        return text
+        return {'text': text, 'avg_logprob': avg_logprobs}  # Return as a dictionary
+
 
     def encode(self, features: np.ndarray) -> ctranslate2.StorageView:
         # When the model is running on multiple GPUs, the encoder output should be moved
@@ -225,8 +237,9 @@ class FasterWhisperPipeline(Pipeline):
         return {'inputs': features}
 
     def _forward(self, model_inputs):
-        outputs = self.model.generate_segment_batched(model_inputs['inputs'], self.tokenizer, self.options)
-        return {'text': outputs}
+        model_outputs = self.model.generate_segment_batched(model_inputs['inputs'], self.tokenizer, self.options)
+        return model_outputs
+
 
     def postprocess(self, model_outputs):
         return model_outputs
@@ -287,11 +300,15 @@ class FasterWhisperPipeline(Pipeline):
         batch_size = batch_size or self._batch_size
         for idx, out in enumerate(self.__call__(data(audio, vad_segments), batch_size=batch_size, num_workers=num_workers)):
             text = out['text']
+            avg_logprob = out['avg_logprob']
+            # full_results = out['results']
             if batch_size in [0, 1, None]:
                 text = text[0]
+                avg_logprob = avg_logprob[0]
             segments.append(
                 {
                     "text": text,
+                    "avg_logprob": avg_logprob,  # Include average log probabilities in the output
                     "start": round(vad_segments[idx]['start'], 3),
                     "end": round(vad_segments[idx]['end'], 3)
                 }

--- a/whisperx/types.py
+++ b/whisperx/types.py
@@ -28,6 +28,7 @@ class SingleSegment(TypedDict):
     start: float
     end: float
     text: str
+    avg_logprob: float
 
 
 class SingleAlignedSegment(TypedDict):


### PR DESCRIPTION
faster-whisper can output avg_logsprobs - this is a patch to pass them to whisperx.transcribe.
kept changes minimal & tested everything.

note: I couldn't figure out how to pass the avg_logsprobs to alignment / diarization & built a workaround for myself, you can call it after alignment / diarization if you save the initial result + the last result:

```python
def match_segments(first_dict, second_dict):
    aligned_segments = []

    for first_segment in first_dict['segments']:
        aligned_segment = None
        closest_difference = float('inf')

        for second_segment in second_dict['segments']:
            # Compute the difference in start and end times
            start_difference = abs(first_segment['start'] - second_segment['start'])
            end_difference = abs(first_segment['end'] - second_segment['end'])
            total_difference = start_difference + end_difference

            # Check if this segment is the closest match
            if total_difference < closest_difference:
                closest_difference = total_difference
                aligned_segment = second_segment.copy()

        # Add avg_logprob to the closest matching segment
        if aligned_segment:
            aligned_segment['avg_logprob'] = first_segment['avg_logprob']
            aligned_segments.append(aligned_segment)

    return {'segments': aligned_segments}


matched_segments = match_segments(result, result_align)
```