### PR TITLE
 adds link to whisperX medium on replicate.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,10 @@ print(result["segments"]) # segments are now assigned speaker IDs
 
 ## Demos 🚀
 
-[![Replicate](https://replicate.com/daanelson/whisperx/badge)](https://replicate.com/daanelson/whisperx) 
+[![Replicate (large-v2](https://img.shields.io/static/v1?label=Replicate+WhisperX+large-v2&message=Demo+%26+Cloud+API&color=blue)](https://replicate.com/daanelson/whisperx) 
+[![Replicate (medium)](https://img.shields.io/static/v1?label=Replicate+WhisperX+medium&message=Demo+%26+Cloud+API&color=blue)](https://replicate.com/carnifexer/whisperx) 
 
-If you don't have access to your own GPUs, use the link above to try out WhisperX. 
+If you don't have access to your own GPUs, use the links above to try out WhisperX. 
 
 <h2 align="left" id="whisper-mod">Technical Details 👷‍♂️</h2>
 


### PR DESCRIPTION
- I have created an additional replicate instance of whisperX using the medium model.
  -  For me, the medium model dramatically reduces the likelihood of whisperX switching to other languages (like Spanish) when transcribing a non-native English speaker.
