### PR TITLE
feat: Add merge chunks chunk_size as arguments.

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -247,7 +247,7 @@ class FasterWhisperPipeline(Pipeline):
         return final_iterator
 
     def transcribe(
-        self, audio: Union[str, np.ndarray], batch_size=None, num_workers=0, language=None, task=None
+        self, audio: Union[str, np.ndarray], batch_size=None, num_workers=0, language=None, task=None, chunk_size=30
     ) -> TranscriptionResult:
         if isinstance(audio, str):
             audio = load_audio(audio)
@@ -260,7 +260,7 @@ class FasterWhisperPipeline(Pipeline):
                 yield {'inputs': audio[f1:f2]}
 
         vad_segments = self.vad_model({"waveform": torch.from_numpy(audio).unsqueeze(0), "sample_rate": SAMPLE_RATE})
-        vad_segments = merge_chunks(vad_segments, 30)
+        vad_segments = merge_chunks(vad_segments, chunk_size)
         if self.tokenizer is None:
             language = language or self.detect_language(audio)
             task = task or "transcribe"

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -41,6 +41,7 @@ def cli():
     # vad params
     parser.add_argument("--vad_onset", type=float, default=0.500, help="Onset threshold for VAD (see pyannote.audio), reduce this if speech is not being detected")
     parser.add_argument("--vad_offset", type=float, default=0.363, help="Offset threshold for VAD (see pyannote.audio), reduce this if speech is not being detected.")
+    parser.add_argument("--chunk_size", type=int, default=30, help="Chunk size for merging VAD segments. Default is 30, reduce this if the chunk is too long.")
 
     # diarization params
     parser.add_argument("--diarize", action="store_true", help="Apply diarization to assign speaker labels to each segment/word")
@@ -101,6 +102,8 @@ def cli():
     vad_onset: float = args.pop("vad_onset")
     vad_offset: float = args.pop("vad_offset")
 
+    chunk_size: int = args.pop("chunk_size")
+
     diarize: bool = args.pop("diarize")
     min_speakers: int = args.pop("min_speakers")
     max_speakers: int = args.pop("max_speakers")
@@ -156,7 +159,7 @@ def cli():
         audio = load_audio(audio_path)
         # >> VAD & ASR
         print(">>Performing transcription...")
-        result = model.transcribe(audio, batch_size=batch_size)
+        result = model.transcribe(audio, batch_size=batch_size, chunk_size=chunk_size)
         results.append((result, audio_path))
 
     # Unload Whisper and VAD


### PR DESCRIPTION
Suggest from https://github.com/m-bain/whisperX/issues/200#issuecomment-1666507780

This PR add a argument `chunk_size` with `int` input
Default is 30, reduce this if the chunk is too long.

```
whisperx --chunk_size 30 audio.wav
```

The length of sentences in different languages varies. I believe it is reasonable to extract the chunk_size as a parameter. 

In the case of Chinese and Japanese, the suggested value of 5~10 (by @seset) is relatively appropriate. You can clearly see the difference in the following image.

| chunk size 6 | chunk size 30 |
|-|-|
|![2023-08-29 23 46 52](https://github.com/m-bain/whisperX/assets/16995691/b98f320a-085a-41be-9b07-b34ace5a2186)|![2023-08-29 23 47 28](https://github.com/m-bain/whisperX/assets/16995691/c3ab31db-c8d6-46dd-9472-f1bc323013a8)|

![2023-08-29 23 44 36](https://github.com/m-bain/whisperX/assets/16995691/a138d76f-0a18-44f0-8382-0b5e45ebea73)