### PR TITLE
chore(writer): improve text display(ja etc) in json file

### DIFF
--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -402,7 +402,7 @@ class WriteJSON(ResultWriter):
     extension: str = "json"
 
     def write_result(self, result: dict, file: TextIO, options: dict):
-        json.dump(result, file)
+        json.dump(result, file, ensure_ascii=False)
 
 
 def get_writer(


### PR DESCRIPTION
Currently, certain utf-8 characters will be saved in `\uxxx` format in the `.json` file, for example, the japanese characters. This makes it hard for developers to inspect the most complete output of whisperx.

The commit will encode the related characters in their original format