### PR TITLE
Fix Diarization Model Name Update

### DIFF
--- a/whisperx/diarize.py
+++ b/whisperx/diarize.py
@@ -9,7 +9,7 @@ from .audio import load_audio, SAMPLE_RATE
 class DiarizationPipeline:
     def __init__(
         self,
-        model_name="pyannote/speaker-diarization@2.1",
+        model_name="pyannote/speaker-diarization-2.1",
         use_auth_token=None,
         device: Optional[Union[str, torch.device]] = "cpu",
     ):

--- a/whisperx/diarize.py
+++ b/whisperx/diarize.py
@@ -9,7 +9,7 @@ from .audio import load_audio, SAMPLE_RATE
 class DiarizationPipeline:
     def __init__(
         self,
-        model_name="pyannote/speaker-diarization-2.1",
+        model_name="pyannote/speaker-diarization",
         use_auth_token=None,
         device: Optional[Union[str, torch.device]] = "cpu",
     ):


### PR DESCRIPTION
- HuggingFace pyannote/speaker-diarization-2.1 name changed. Old name leads to the following error on a machine without cached model
![Screenshot 2023-09-26 054440](https://github.com/m-bain/whisperX/assets/13636972/7e6c467f-ce36-411c-b9a8-57f25d46c8b0)
- `pyannote/speaker-diarization-2.1` fixes the issue