### PR TITLE
Update setup.py to download pyannote depending on platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,15 @@
 import os
-
+import platform
 import pkg_resources
 from setuptools import setup, find_packages
+
+
+def get_pyannote_audio_version():
+    machine = platform.machine()
+    system = platform.system()
+    version = "3.0.0" if machine == "aarch64" or system == "Darwin" else "3.0.1"
+    return version
+
 
 setup(
     name="whisperx",
@@ -19,10 +27,11 @@ setup(
         for r in pkg_resources.parse_requirements(
             open(os.path.join(os.path.dirname(__file__), "requirements.txt"))
         )
-    ] + ["pyannote.audio==3.0.1"],
-    entry_points = {
-        'console_scripts': ['whisperx=whisperx.transcribe:cli'],
+    ]
+    + [f"pyannote.audio=={get_pyannote_audio_version()}"],
+    entry_points={
+        "console_scripts": ["whisperx=whisperx.transcribe:cli"],
     },
     include_package_data=True,
-    extras_require={'dev': ['pytest']},
+    extras_require={"dev": ["pytest"]},
 )


### PR DESCRIPTION
https://github.com/m-bain/whisperX/issues/540

Breaks Mac platform and arm64 platforms. 

Tested by successfully building on my m1 mac doing:
pip install .

And also using Depot (a way to build Dockerfiles remotely, using arm64):
depot build -t whisperx_image . --platform linux/arm64 --load