### PR TITLE
Add new option to generate subtitles by a specific number of words

### DIFF
--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -69,6 +69,7 @@ def cli():
     parser.add_argument("--max_line_width", type=optional_int, default=None, help="(not possible with --no_align) the maximum number of characters in a line before breaking the line")
     parser.add_argument("--max_line_count", type=optional_int, default=None, help="(requires --no_align) the maximum number of lines in a segment")
     parser.add_argument("--highlight_words", type=str2bool, default=False, help="(requires --word_timestamps True) underline each word as it is spoken in srt and vtt")
+    parser.add_argument("--max_words_count", type=optional_int, default=None, help="the maximum number of words in a segment")
     parser.add_argument("--segment_resolution", type=str, default="sentence", choices=["sentence", "chunk"], help="(not possible with --no_align) the maximum number of characters in a line before breaking the line")
 
     parser.add_argument("--threads", type=optional_int, default=0, help="number of threads used by torch for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS")
@@ -153,7 +154,7 @@ def cli():
     }
 
     writer = get_writer(output_format, output_dir)
-    word_options = ["highlight_words", "max_line_count", "max_line_width"]
+    word_options = ["highlight_words", "max_line_count", "max_line_width", "max_words_count"]
     if no_align:
         for option in word_options:
             if args[option]:

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -224,7 +224,9 @@ class SubtitlesWriter(ResultWriter):
         raw_max_line_width: Optional[int] = options["max_line_width"]
         max_line_count: Optional[int] = options["max_line_count"]
         highlight_words: bool = options["highlight_words"]
+        max_words_count: Optional[int] = options["max_words_count"]
         max_line_width = 1000 if raw_max_line_width is None else raw_max_line_width
+        max_words_count = 1000 if max_words_count is None else max_words_count
         preserve_segments = max_line_count is None or raw_max_line_width is None
         
         if len(result["segments"]) == 0:
@@ -241,49 +243,56 @@ class SubtitlesWriter(ResultWriter):
             times = []
             last = result["segments"][0]["start"]
             for segment in result["segments"]:
-                for i, original_timing in enumerate(segment["words"]):
-                    timing = original_timing.copy()
-                    long_pause = not preserve_segments
-                    if "start" in timing:
-                        long_pause = long_pause and timing["start"] - last > 3.0
-                    else:
-                        long_pause = False
-                    has_room = line_len + len(timing["word"]) <= max_line_width
-                    seg_break = i == 0 and len(subtitle) > 0 and preserve_segments
-                    if line_len > 0 and has_room and not long_pause and not seg_break:
-                        # line continuation
-                        line_len += len(timing["word"])
-                    else:
-                        # new line
-                        timing["word"] = timing["word"].strip()
-                        if (
-                            len(subtitle) > 0
-                            and max_line_count is not None
-                            and (long_pause or line_count >= max_line_count)
-                            or seg_break
-                        ):
-                            # subtitle break
-                            yield subtitle, times
-                            subtitle = []
-                            times = []
-                            line_count = 1
-                        elif line_len > 0:
-                            # line break
-                            line_count += 1
-                            timing["word"] = "\n" + timing["word"]
-                        line_len = len(timing["word"].strip())
-                    subtitle.append(timing)
-                    times.append((segment["start"], segment["end"], segment.get("speaker")))
-                    if "start" in timing:
-                        last = timing["start"]
+                chunk_index = 0
+                words = segment["words"]
+                words_count = max_words_count
+                while chunk_index < len(segment["words"]):
+                    if len(words) - chunk_index < max_words_count:
+                        words_count = len(words) - chunk_index
+                    for i, original_timing in enumerate(words[chunk_index:chunk_index + words_count]):
+                        timing = original_timing.copy()
+                        long_pause = not preserve_segments
+                        if "start" in timing:
+                            long_pause = long_pause and timing["start"] - last > 3.0
+                        else:
+                            long_pause = False
+                        has_room = line_len + len(timing["word"]) <= max_line_width
+                        seg_break = i == 0 and len(subtitle) > 0 and preserve_segments
+                        if line_len > 0 and has_room and not long_pause and not seg_break:
+                            # line continuation
+                            line_len += len(timing["word"])
+                        else:
+                            # new line
+                            timing["word"] = timing["word"].strip()
+                            if (
+                                len(subtitle) > 0
+                                and max_line_count is not None
+                                and (long_pause or line_count >= max_line_count)
+                                or seg_break
+                            ):
+                                # subtitle break
+                                yield subtitle, times
+                                subtitle = []
+                                times = []
+                                line_count = 1
+                            elif line_len > 0:
+                                # line break
+                                line_count += 1
+                                timing["word"] = "\n" + timing["word"]
+                            line_len = len(timing["word"].strip())
+                        subtitle.append(timing)
+                        times.append((words[chunk_index]["start"], words[chunk_index + words_count-1]["end"], segment.get("speaker")))
+                        if "start" in timing:
+                            last = timing["start"]
+                    chunk_index += max_words_count
             if len(subtitle) > 0:
                 yield subtitle, times
 
         if "words" in result["segments"][0]:
-            for subtitle, _ in iterate_subtitles():
-                sstart, ssend, speaker = _[0]
-                subtitle_start = self.format_timestamp(sstart)
-                subtitle_end = self.format_timestamp(ssend)
+            for subtitle, times in iterate_subtitles():
+                speaker = times[0][2]
+                subtitle_start = self.format_timestamp(times[0][0])
+                subtitle_end = self.format_timestamp(times[-1][1])
                 if result["language"] in LANGUAGES_WITHOUT_SPACES:
                     subtitle_text = "".join([word["word"] for word in subtitle])
                 else:


### PR DESCRIPTION
Added a new word option called **--max_words_count** that will generate subtitles setting a maximum limit of words per segment.

I've opened the same PR in Whisper: [https://github.com/openai/whisper/pull/1729]() with some slightly changes:

- All options are compatible: **"highlight_words", "max_line_count", "max_line_width" and "max_words_count"**.
- Tested with/without diarization.
- Please pay attention to the changes when I handle "times" in iterate_subtitles() on util.py file. I've wanted to minimize the impact on the current behavior, but I changed the times we yield so now they match the chunk of words set instead of the original segment.

The rest is just a copy/paste of the original PR description:

Added a new word option called **--max_words_count** that will generate subtitles setting a maximum limit of words per segment. This could sound similar to **--max_line_width** option, but the results are more pleasent for readers IMHO. Here a couple of comparisons using .SRT files:

![max_word_count](https://github.com/openai/whisper/assets/8297398/735207d6-c6a6-4790-81f2-e5d9ccd6833f)
Notice that **--max_words_count** works as an upper bound of words, but still it will respect the segments in the way that end of sentences can have less words if the remaining number of words in a segment is lower than the max_words_count value.
i.e. _Segment = [word1, word2, word3, word4, word5] and max_words_count = 3
=>Result = [word1, word2, word3] and [word4, word5]_
This is not the behaviour we can see using **--max_line_width** that can leave bigger gaps of time when joining end and beginning of segments:
![WidthvsWords](https://github.com/openai/whisper/assets/8297398/3f7d4648-5c0b-48fa-832f-52ad925bf954)

Subtitles generated with **--max_words_count** look similar of what we can see in Shorts, Reels and other short duration videos.

This is my first contribution, so feel free of changing/comment/improve anything.

### Additional notes

- Manually tested using Python and cli and checked results in .srt and .vtt files (.txt. and .tsv files won't be affected).

This is my first contribution, so feel free of changing/comment/improve anything.
