### PR TITLE
Minor fixes for word options and subtitles

### DIFF
--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -67,8 +67,8 @@ def cli():
     parser.add_argument("--no_speech_threshold", type=optional_float, default=0.6, help="if the probability of the <|nospeech|> token is higher than this value AND the decoding has failed due to `logprob_threshold`, consider the segment as silence")
 
     parser.add_argument("--max_line_width", type=optional_int, default=None, help="(not possible with --no_align) the maximum number of characters in a line before breaking the line")
-    parser.add_argument("--max_line_count", type=optional_int, default=None, help="(requires --no_align) the maximum number of lines in a segment")
-    parser.add_argument("--highlight_words", type=str2bool, default=False, help="(requires --word_timestamps True) underline each word as it is spoken in srt and vtt")
+    parser.add_argument("--max_line_count", type=optional_int, default=None, help="(not possible with --no_align) the maximum number of lines in a segment")
+    parser.add_argument("--highlight_words", type=str2bool, default=False, help="(not possible with --no_align) underline each word as it is spoken in srt and vtt")
     parser.add_argument("--segment_resolution", type=str, default="sentence", choices=["sentence", "chunk"], help="(not possible with --no_align) the maximum number of characters in a line before breaking the line")
 
     parser.add_argument("--threads", type=optional_int, default=0, help="number of threads used by torch for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS")
@@ -157,7 +157,7 @@ def cli():
     if no_align:
         for option in word_options:
             if args[option]:
-                parser.error(f"--{option} requires --word_timestamps True")
+                parser.error(f"--{option} not possible with --no_align")
     if args["max_line_count"] and not args["max_line_width"]:
         warnings.warn("--max_line_count has no effect without --max_line_width")
     writer_args = {arg: args.pop(arg) for arg in word_options}

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -226,9 +226,6 @@ class SubtitlesWriter(ResultWriter):
         highlight_words: bool = options["highlight_words"]
         max_line_width = 1000 if raw_max_line_width is None else raw_max_line_width
         preserve_segments = max_line_count is None or raw_max_line_width is None
-        
-        if len(result["segments"]) == 0:
-            return
 
         if len(result["segments"]) == 0:
             return


### PR DESCRIPTION
Some minor fixes I noticed when I was making changes for [https://github.com/m-bain/whisperX/pull/548]()

- Removed references to **--word-timestamps** as it's not a valid option in WhisperX. Rephrased to **(not possible with --no_align)** as word options need the word segments that are generated when doing the alignment. **PLEASE CORRECT ME IF I'M WRONG.**
- Removed some duplicated code.