### PR TITLE
feat(align-model-hf): add default Romanian(ro) default align model in HuggingFace

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -50,7 +50,8 @@ DEFAULT_ALIGN_MODELS_HF = {
     "ko": "kresnik/wav2vec2-large-xlsr-korean",
     "ur": "kingabzpro/wav2vec2-large-xls-r-300m-Urdu",
     "te": "anuragshas/wav2vec2-large-xlsr-53-telugu",
-    "hi": "theainerd/Wav2Vec2-large-xlsr-hindi"
+    "hi": "theainerd/Wav2Vec2-large-xlsr-hindi",
+    "ro": "anton-l/wav2vec2-large-xlsr-53-romanian",
 }
 
 


### PR DESCRIPTION
## What's

I found a Romanian align model from hugging face: https://huggingface.co/anton-l/wav2vec2-large-xlsr-53-romanian
It has over 1K downloads and I test it in one sample audio, it works.
So I put it here if you need this.