### PR TITLE
fix unboundlocalerror

### DIFF
--- a/whisperx/vad.py
+++ b/whisperx/vad.py
@@ -142,6 +142,7 @@ class Binarize:
             is_active = k_scores[0] > self.onset
             curr_scores = [k_scores[0]]
             curr_timestamps = [start]
+            t = start
             for t, y in zip(timestamps[1:], k_scores[1:]):
                 # currently active
                 if is_active: 


### PR DESCRIPTION
Should resolve #511 
I'm not 100% happy with my solution but usually t should be overridden. If it's not we are talking about such a short audio that there is no reasonable way to handle alignment.