### PR TITLE
no align based on space

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -283,7 +283,8 @@ def align(
         
             sentence_text = text[sstart:send]
             sentence_start = curr_chars["start"].min()
-            sentence_end = curr_chars["end"].max()
+            end_chars = curr_chars[curr_chars["char"] != ' ']
+            sentence_end = end_chars["end"].max()
             sentence_words = []
 
             for word_idx in curr_chars["word-idx"].unique():


### PR DESCRIPTION
Words already were not aligned based on the end of space characters, this was still the case for the whole segment. As such, 
```bash
ffmpeg -i "https://mediandr-a.akamaihd.net/progressive/2022/1118/TV-20221118-2201-5200.ln.mp4" -ac 1 -ar 16000 test.wav
whisperx test.wav --model small --compute_type="float32" --language "de"
``` 
yielded 
```json
{"start": 1.178, "end": 4.5, "text": " Der Traum vom Rekordschiff Made in Mecklenburg-Vorpommern.", "words": [{"word": "Der", "start": 1.178, "end": 1.318, "score": 0.945}, {"word": "Traum", "start": 1.358, "end": 1.598, "score": 0.893}, {"word": "vom", "start": 1.638, "end": 1.878, "score": 0.962}, {"word": "Rekordschiff", "start": 1.938, "end": 2.679, "score": 0.776}, {"word": "Made", "start": 2.719, "end": 2.919, "score": 0.83}, {"word": "in", "start": 2.959, "end": 3.079, "score": 0.84}, {"word": "Mecklenburg-Vorpommern.", "start": 3.119, "end": 4.44, "score": 0.76}]}, {"start": 4.5, "end": 8.281, "text": "Im November 2019 kommt die Global Dream nach Wismar."
```

I would prefer the segment to end at `4.44` as well, it does now.