### PR TITLE
Update diarize.py

### DIFF
--- a/whisperx/diarize.py
+++ b/whisperx/diarize.py
@@ -45,7 +45,7 @@ def assign_word_speakers(diarize_df, transcript_result, fill_nearest=False):
             dia_tmp = diarize_df
         if len(dia_tmp) > 0:
             # sum over speakers
-            speaker = dia_tmp.groupby("speaker")["intersection"].sum().sort_values(ascending=False).index[0]
+            speaker = dia_tmp.sort_values(by=["intersection"], ascending=False)["speaker"].values[0]
             seg["speaker"] = speaker
         
         # assign speaker to words
@@ -61,7 +61,7 @@ def assign_word_speakers(diarize_df, transcript_result, fill_nearest=False):
                         dia_tmp = diarize_df
                     if len(dia_tmp) > 0:
                         # sum over speakers
-                        speaker = dia_tmp.groupby("speaker")["intersection"].sum().sort_values(ascending=False).index[0]
+                        speaker = dia_tmp.sort_values(by=["intersection"], ascending=False)["speaker"].values[0]
                         word["speaker"] = speaker
         
     return transcript_result            


### PR DESCRIPTION
Hello! Seems like here is mistake. We should look for closest instead of sum.

Simple counterexample:
```
predicted_sample - [0,1]

diarization_segments:
SPEAKER_00: [2, 3], [4, 5]
SPEAKER_01: [3, 4]
```

For SPEAKER_00 value of `dia_tmp.groupby("speaker")["intersection"].sum().sort_values(ascending=False).index[0]` will be `sum([-1, -3]) = -4`.
For SPEAKER_01 value will be `sum([-2]) = -2`.

And therefore we will choose SPEAKER_01, even if it is not the closest