### PR TITLE
Specify install from git correctly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=2
 torchaudio>=2
-git+https://github.com/SYSTRAN/faster-whisper.git@0.10.0
+faster-whisper @ git+https://github.com/SYSTRAN/faster-whisper.git@0.10.0
 transformers
 pandas
 setuptools>=65


### PR DESCRIPTION
This allows for installing with pip `pip install git+https://github.com/m-bain/whisperx.git`

Issue initially described [here](https://github.com/m-bain/whisperX/commit/b4e4143e3b1934291d416eddb3aa3d3bc810123c#commitcomment-133522496)