### PR TITLE
Update README to correct speaker diarization version link

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ pip install -e .
 You may also need to install ffmpeg, rust etc. Follow openAI instructions here https://github.com/openai/whisper#setup.
 
 ### Speaker Diarization
-To **enable Speaker Diarization**, include your Hugging Face access token (read) that you can generate from [Here](https://huggingface.co/settings/tokens) after the `--hf_token` argument and accept the user agreement for the following models: [Segmentation](https://huggingface.co/pyannote/segmentation-3.0) and [Speaker-Diarization-3.0](https://huggingface.co/pyannote/speaker-diarization-3.0) (if you choose to use Speaker-Diarization 2.x, follow requirements [here](https://huggingface.co/pyannote/speaker-diarization) instead.)
+To **enable Speaker Diarization**, include your Hugging Face access token (read) that you can generate from [Here](https://huggingface.co/settings/tokens) after the `--hf_token` argument and accept the user agreement for the following models: [Segmentation](https://huggingface.co/pyannote/segmentation-3.0) and [Speaker-Diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1) (if you choose to use Speaker-Diarization 2.x, follow requirements [here](https://huggingface.co/pyannote/speaker-diarization) instead.)
 
 > **Note**<br>
 > As of Oct 11, 2023, there is a known issue regarding slow performance with pyannote/Speaker-Diarization-3.0 in whisperX. It is due to dependency conflicts between faster-whisper and pyannote-audio 3.0.0. Please see [this issue](https://github.com/m-bain/whisperX/issues/499) for more details and potential workarounds.


### PR DESCRIPTION
Updates the README to link to the correct version of pyannote, since it seemed to only work when I agreed to the version 3.1 terms

Can confirm version 3.1 is much faster, my own benchmark from today:
Machine: RTX 3060 12GB, Xeon E5-2698 v3
Time for running whisperx with `--diarize` flag on 5min mp3:
With pyannote version 3.0: 164 seconds
With pyannote version 3.1: 45-60 seconds
Speedup: 3-4x

I could remove the README warning about using version 3.0, or maybe it's good to leave it for those who haven't pulled lately?

Best regards,
Sean

PS:
Thanks to the maintainer for their ongoing support and to @remic33 for their recent update with the new pyannote version. Apologies for spamming multiple commit references in the original PR caused by pushes to my fork. Was unaware of this GitHub behavior and appreciate your understanding.