### PR TITLE
Improve alignment accuracy by normalizing audio features using Wav2Ve…

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -102,6 +102,7 @@ def align(
     return_char_alignments: bool = False,
     print_progress: bool = False,
     combined_progress: bool = False,
+    Preprocess: bool = True,
 ) -> AlignedTranscriptionResult:
     """
     Align phoneme recognition predictions to known transcription.
@@ -119,6 +120,11 @@ def align(
     model_dictionary = align_model_metadata["dictionary"]
     model_lang = align_model_metadata["language"]
     model_type = align_model_metadata["type"]
+
+    # Load align model Huggingface processor for audio feature extraction (Normalization)
+    if preprocess and model_type == 'huggingface':
+        processor = Wav2Vec2Processor.from_pretrained(
+            DEFAULT_ALIGN_MODELS_HF[model_lang])
 
     # 1. Preprocess to keep only characters in dictionary
     total_segments = len(transcript)
@@ -222,7 +228,11 @@ def align(
             if model_type == "torchaudio":
                 emissions, _ = model(waveform_segment.to(device), lengths=lengths)
             elif model_type == "huggingface":
-                emissions = model(waveform_segment.to(device)).logits
+                if preprocess:
+                    inputs = processor(waveform_segment.squeeze(), sampling_rate=processor.sampling_rate, return_tensors="pt").to(device)
+                    emissions = model(**inputs).logits
+                else:
+                    emissions = model(waveform_segment.to(device)).logits
             else:
                 raise NotImplementedError(f"Align model of type {model_type} not supported.")
             emissions = torch.log_softmax(emissions, dim=-1)


### PR DESCRIPTION
Audio data should be pre-processed using the `Wav2Vec2Processor (Wav2Vec2FeatureExtractor)`, I have noticed considerable alignment improvement `(Mean absolute error)` when audio is normalized `(zero mean and unit variance)` using the processor before the forward pass.

Other than that, Each Hugging face Wav2Vec2 Feature Extractor configuration should contain the same config used during fine-tuning these models (e.g. normalization, attention_mask usage, etc..) 

A typical `hugging face Wav2Vec2 Feature Extractor config file` is as follows:

```text
{
  "do_normalize": true,
  "feature_size": 1,
  "padding_side": "right",
  "padding_value": 0.0,
  "return_attention_mask": true,
  "sampling_rate": 16000
}
```
To maintain backwards compatibility, I have opted to let the user determine if Pre-processing should be applied or not, but chose to set `Pre-processing as the default option` as it improves alignment considerably.
