### PR TITLE
Adding Norwegian Bokmål and Norwegian Nynorsk

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -53,6 +53,8 @@ DEFAULT_ALIGN_MODELS_HF = {
     "hi": "theainerd/Wav2Vec2-large-xlsr-hindi",
     "ca": "softcatala/wav2vec2-large-xlsr-catala",
     "ml": "gvs/wav2vec2-large-xlsr-malayalam",
+    "no": "NbAiLab/nb-wav2vec2-1b-bokmaal",
+    "nn": "NbAiLab/nb-wav2vec2-300m-nynorsk",
 }
 
 


### PR DESCRIPTION
Adding Wav2Vec2-models for Norwegian Bokmål and Norwegian Nynorsk. The models are testet together with WhisperX, and works great. For Bokmål I have added the 1B model, even if I see fairly little difference between that and the 300M model. For Norwegian Nynorsk only a 300M model exist. The quality of the Wav2Vec models are also reported here: https://arxiv.org/abs/2307.01672