### PR TITLE
Enable offline use for DiarizationPipeline and let users choose if they want to print suppress_numerals message.

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -171,7 +171,7 @@ class FasterWhisperPipeline(Pipeline):
         return final_iterator
 
     def transcribe(
-        self, audio: Union[str, np.ndarray], batch_size=None, num_workers=0, language=None, task=None, chunk_size=30, print_progress = False, combined_progress=False
+        self, audio: Union[str, np.ndarray], batch_size=None, num_workers=0, language=None, task=None, chunk_size=30, print_progress = False, combined_progress=False, supress_numerals_print_flag = True
     ) -> TranscriptionResult:
         if isinstance(audio, str):
             audio = load_audio(audio)
@@ -207,7 +207,7 @@ class FasterWhisperPipeline(Pipeline):
         if self.suppress_numerals:
             previous_suppress_tokens = self.options.suppress_tokens
             numeral_symbol_tokens = find_numeral_symbol_tokens(self.tokenizer)
-            print(f"Suppressing numeral and symbol tokens: {numeral_symbol_tokens}")
+            if supress_numerals_print_flag: print(f"Suppressing numeral and symbol tokens: {numeral_symbol_tokens}")
             new_suppressed_tokens = numeral_symbol_tokens + self.options.suppress_tokens
             new_suppressed_tokens = list(set(new_suppressed_tokens))
             self.options = self.options._replace(suppress_tokens=new_suppressed_tokens)

--- a/whisperx/diarize.py
+++ b/whisperx/diarize.py
@@ -13,10 +13,15 @@ class DiarizationPipeline:
         model_name="pyannote/speaker-diarization-3.1",
         use_auth_token=None,
         device: Optional[Union[str, torch.device]] = "cpu",
+        offline_use = False,
+        config_path = "config.yaml"
     ):
         if isinstance(device, str):
             device = torch.device(device)
-        self.model = Pipeline.from_pretrained(model_name, use_auth_token=use_auth_token).to(device)
+        if offline_use:
+            self.model = Pipeline.from_pretrained(config_path).to(device)
+        else:
+            self.model = Pipeline.from_pretrained(model_name, use_auth_token=use_auth_token).to(device)
 
     def __call__(self, audio: Union[str, np.ndarray], num_speakers=None, min_speakers=None, max_speakers=None):
         if isinstance(audio, str):


### PR DESCRIPTION
Hi,

I have made a couple of changes that I think will be useful for others:

1) The first change is related to issue #674. Currently, Diarization pipeline doesn't have an option load model from a directory. I enabled that by following the tutorial here: "[Can I use gated models (and pipelines) offline?](https://github.com/pyannote/pyannote-audio/blob/develop/FAQ.md#can-i-use-gated-models-(and-pipelines)-offline)". In short, users can download the config.yaml and the pytorch model files from huggingface locally and use them in the pipeline.

2) Currently, when you enable suppress_numerals flag, a huge message is printed on the console. I introduced a flag so that users can choose if they want this print message or not.

Let me know if you have any questions. Thanks!

