### PR TITLE
Add Replicate large-v3 demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ print(result["segments"]) # segments are now assigned speaker IDs
 
 ## Demos 🚀
 
+[![Replicate (large-v3](https://img.shields.io/static/v1?label=Replicate+WhisperX+large-v3&message=Demo+%26+Cloud+API&color=blue)](https://replicate.com/victor-upmeet/whisperx) 
 [![Replicate (large-v2](https://img.shields.io/static/v1?label=Replicate+WhisperX+large-v2&message=Demo+%26+Cloud+API&color=blue)](https://replicate.com/daanelson/whisperx) 
 [![Replicate (medium)](https://img.shields.io/static/v1?label=Replicate+WhisperX+medium&message=Demo+%26+Cloud+API&color=blue)](https://replicate.com/carnifexer/whisperx) 
 


### PR DESCRIPTION
Hello,

I wanted to add a link to a Replicate model I made in the README of this project. The differences between this model and the previous ones are that it uses the large-v3 model, and it accepts more input parameters to customize inference (you can set the language, the initial prompt, VAD parameters, activate diarization and set parameters for it).