### PR TITLE
Updated faster-whisper version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=2
 torchaudio>=2
-faster-whisper @ git+https://github.com/SYSTRAN/faster-whisper.git@0.10.0
+faster-whisper @ git+https://github.com/SYSTRAN/faster-whisper.git@v0.10.1
 transformers
 pandas
 setuptools>=65


### PR DESCRIPTION
Installing library leading to conflicts due to version issue in fasterwhisper.
Faster whisper does not have branch `0.10.0` anymore. It has been updated to `v0.10.1`.

Have done the necessary changes in the requirements.txt.
