### PR TITLE
Change faster-whisper dependency from `0.10.0` to `v0.10.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=2
 torchaudio>=2
-faster-whisper @ git+https://github.com/SYSTRAN/faster-whisper.git@0.10.0
+faster-whisper @ git+https://github.com/SYSTRAN/faster-whisper.git@v0.10.0
 transformers
 pandas
 setuptools>=65


### PR DESCRIPTION
pip install fails right now. 

I am guessing they renamed the tag?