### PR TITLE
fix: update faster-whisper dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=2
 torchaudio>=2
-faster-whisper @ git+https://github.com/SYSTRAN/faster-whisper.git@0.10.0
+faster-whisper~=0.10.0
 transformers
 pandas
 setuptools>=65


### PR DESCRIPTION
Fix #715

As pointed out in #715, the current requirements.txt fails to install faster-whisper. Additionally, as mentioned in https://github.com/m-bain/whisperX/pull/710#issuecomment-1959400388, the PyPI version of faster-whisper has already been updated, and there is no longer a need to install directly from GitHub.