### PR TITLE
Speechbrain+faster whisper downgrade needed to make WhisperX work. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 torch>=2
 torchaudio>=2
-faster-whisper==1.0.0
+faster-whisper==0.10.1
 transformers
 pandas
 setuptools>=65
 nltk
+speechbrain==0.5.16


### PR DESCRIPTION
Hello!

This project only will work with speechbrain 0.5.16 and faster-whisper 0.10.1

Recently speechbrain upgraded to 1.0.0 which is [not compatible](https://github.com/m-bain/whisperX/issues/723) with the current version of whisperx.

On the other hand faster-whisper 1.0.0 has [breaking changes](https://github.com/m-bain/whisperX/issues/711) with the current latest version of whisperx too.

I already tested this in my project and made it work https://github.com/davidmartinrius/speech-dataset-generator

So, I just updated requirements.txt to make whisperX latest version work again.

Thank you!