### PR TITLE
Mix out-of-phase stereo audio with phasedetect so it does not cancel out.

### DIFF
--- a/whisperx/audio.py
+++ b/whisperx/audio.py
@@ -48,6 +48,8 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
             "0",
             "-i",
             file,
+            "-af",
+            "asplit[a],aphasemeter=video=0,ametadata=select:key=lavfi.aphasemeter.phase:value=-0.005:function=less,pan=1c|c0=c0,aresample=async=1:first_pts=0,[a]amix", #mix out of phase stereo correctly instead of cancelling out
             "-f",
             "s16le",
             "-ac",


### PR DESCRIPTION
The current ffmpeg downmix with -ac 1 with a broken stereo audio file where the channels are out of phase (inverted) relative to each other, will result in silence or garbage. Example screenshot of such an audio: 

![Screenshot (76)](https://github.com/m-bain/whisperX/assets/10514959/2e18eff8-0e77-4283-90b6-344ea18bb37c)

Adding this filter fixes that, and is taken as-is from the ffmpeg wiki: https://trac.ffmpeg.org/wiki/AudioChannelManipulation