### PR TITLE
Add ultization to verbose flag

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -171,7 +171,7 @@ class FasterWhisperPipeline(Pipeline):
         return final_iterator
 
     def transcribe(
-        self, audio: Union[str, np.ndarray], batch_size=None, num_workers=0, language=None, task=None, chunk_size=30, print_progress = False, combined_progress=False
+        self, audio: Union[str, np.ndarray], batch_size=None, num_workers=0, language=None, task=None, chunk_size=30, print_progress = False, combined_progress=False,verbose=False
     ) -> TranscriptionResult:
         if isinstance(audio, str):
             audio = load_audio(audio)
@@ -223,6 +223,8 @@ class FasterWhisperPipeline(Pipeline):
             text = out['text']
             if batch_size in [0, 1, None]:
                 text = text[0]
+            if verbose:
+                print(f"Transcript: [{round(vad_segments[idx]['start'], 3)} --> {round(vad_segments[idx]['end'], 3)}] {text}")
             segments.append(
                 {
                     "text": text,

--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -171,7 +171,7 @@ class FasterWhisperPipeline(Pipeline):
         return final_iterator
 
     def transcribe(
-        self, audio: Union[str, np.ndarray], batch_size=None, num_workers=0, language=None, task=None, chunk_size=30, print_progress = False, combined_progress=False,verbose=False
+        self, audio: Union[str, np.ndarray], batch_size=None, num_workers=0, language=None, task=None, chunk_size=30, print_progress = False, combined_progress=False, verbose=False
     ) -> TranscriptionResult:
         if isinstance(audio, str):
             audio = load_audio(audio)

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -87,6 +87,7 @@ def cli():
     device: str = args.pop("device")
     device_index: int = args.pop("device_index")
     compute_type: str = args.pop("compute_type")
+    verbose:bool=args.pop("verbose")
 
     # model_flush: bool = args.pop("model_flush")
     os.makedirs(output_dir, exist_ok=True)
@@ -173,7 +174,7 @@ def cli():
         audio = load_audio(audio_path)
         # >> VAD & ASR
         print(">>Performing transcription...")
-        result = model.transcribe(audio, batch_size=batch_size, chunk_size=chunk_size, print_progress=print_progress)
+        result = model.transcribe(audio, batch_size=batch_size, chunk_size=chunk_size, print_progress=print_progress,verbose=verbose)
         results.append((result, audio_path))
 
     # Unload Whisper and VAD

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -87,7 +87,7 @@ def cli():
     device: str = args.pop("device")
     device_index: int = args.pop("device_index")
     compute_type: str = args.pop("compute_type")
-    verbose:bool=args.pop("verbose")
+    verbose: bool = args.pop("verbose")
 
     # model_flush: bool = args.pop("model_flush")
     os.makedirs(output_dir, exist_ok=True)
@@ -174,7 +174,7 @@ def cli():
         audio = load_audio(audio_path)
         # >> VAD & ASR
         print(">>Performing transcription...")
-        result = model.transcribe(audio, batch_size=batch_size, chunk_size=chunk_size, print_progress=print_progress,verbose=verbose)
+        result = model.transcribe(audio, batch_size=batch_size, chunk_size=chunk_size, print_progress=print_progress, verbose=verbose)
         results.append((result, audio_path))
 
     # Unload Whisper and VAD


### PR DESCRIPTION
https://github.com/m-bain/whisperX/issues/738
had the issue with non-functionality of verbose flag and suggested handling it like openai-whisper

Quote from https://github.com/m-bain/whisperX/issues/738
```
In the orginal Openai-Whisper in Python you can set verbose=True, e.g.
result = model.transcribe(input_file,
language='en',
initial_prompt=prompt,
fp16=False,
verbose=True)

This prints the transcription output as the program runs so you can observe any errors in the transcription before it finalises, e.g.
[00:00.000 --> 00:07.000] Okay.
[00:30.000 --> 00:43.680] I'm making inquiries into a workplace dispute that
[00:43.680 --> 00:50.160] has reportedly occurred on Saturday 6 January
[00:50.160 --> 00:51.160] 2024.

Judging from what I can see in transcribe.py, WhisperX has verbose=True set by default. However, nothing is printed
```

Handled the same