### PR TITLE
Update README.md with instructions on how to install with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@ GPU execution requires the NVIDIA libraries cuBLAS 11.x and cuDNN 8.x to be inst
 
 ### 2. Install PyTorch, e.g. for Linux and Windows CUDA11.8:
 
+Conda:
 `conda install pytorch==2.0.0 torchaudio==2.0.0 pytorch-cuda=11.8 -c pytorch -c nvidia`
+
+Pip:
+`pip install lit; pip install torch==2.0.0 torchvision==0.15.1 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu118`
 
 See other methods [here.](https://pytorch.org/get-started/previous-versions/#v200)
 


### PR DESCRIPTION
Current PyTorch instructions don't work out of the box because the `lit` package doesn't exist in the `cu118` index. Installing `lit` in a previous step solves the issue.

See https://github.com/pypa/pip/issues/12050#issuecomment-1948879030 for more details.