### PR TITLE
Fix to Timing Overlap Issue #608 and #621

### DIFF
--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -278,15 +278,19 @@ class SubtitlesWriter(ResultWriter):
                 yield subtitle, times
 
         if "words" in result["segments"][0]:
-            for subtitle, _ in iterate_subtitles():
-                sstart, ssend, speaker = _[0]
+            for subtitle, times in iterate_subtitles():
+                # TODO: handle multiple segments with different start/end times and speakers
+                sstart, send, speaker = times[0]
+                has_timing = any(["start" in timing for timing in subtitle])
+                if has_timing:
+                    sstart = next(timing["start"] for timing in subtitle if "start" in timing)
+                    send = next(timing["end"] for timing in reversed(subtitle) if "end" in timing)
                 subtitle_start = self.format_timestamp(sstart)
-                subtitle_end = self.format_timestamp(ssend)
+                subtitle_end = self.format_timestamp(send)
                 if result["language"] in LANGUAGES_WITHOUT_SPACES:
                     subtitle_text = "".join([word["word"] for word in subtitle])
                 else:
                     subtitle_text = " ".join([word["word"] for word in subtitle])
-                has_timing = any(["start" in word for word in subtitle])
 
                 # add [$SPEAKER_ID]: to each subtitle if speaker is available
                 prefix = ""


### PR DESCRIPTION
Currently the function `iterate_subtitles` does not compute the start and end time correctly for each combined subtitle segment. All it does is selecting the start and end time of the first segement in the combined segement, without considering the following segments or segment breaks. The start and end time of each word is ignored, causing the `--max_line_count` and `--max_line_width` to return segements with overlapped timing, as stated in issue #608 and #621.

https://github.com/m-bain/whisperX/blob/f2da2f858e99e4211fe4f64b5f2938b007827e17/whisperx/utils.py#L274

https://github.com/m-bain/whisperX/blob/f2da2f858e99e4211fe4f64b5f2938b007827e17/whisperx/utils.py#L281-L284

https://github.com/m-bain/whisperX/blob/f2da2f858e99e4211fe4f64b5f2938b007827e17/whisperx/utils.py#L316

---

I added a piece of code to compute the start and end time of the combined segment based on the time of each word in the segment. But I'm not sure how to utilize the `times` yielded by `iterate_subtitles`.
