### PR TITLE
Added local_files_only option on whisperx.load_model for offline mode

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -267,6 +267,7 @@ def load_model(whisper_arch,
                model : Optional[WhisperModel] = None,
                task="transcribe",
                download_root=None,
+               local_files_only=False,
                threads=4):
     '''Load a Whisper model for inference.
     Args:
@@ -277,6 +278,7 @@ def load_model(whisper_arch,
         language: str - The language of the model. (use English for now)
         model: Optional[WhisperModel] - The WhisperModel instance to use.
         download_root: Optional[str] - The root directory to download the model to.
+        local_files_only: Optional[bool] - If `True`, avoid downloading the file and return the path to the local cached file if it exists.
         threads: int - The number of cpu threads to use per worker, e.g. will be multiplied by num workers.
     Returns:
         A Whisper pipeline.
@@ -290,6 +292,7 @@ def load_model(whisper_arch,
                          device_index=device_index,
                          compute_type=compute_type,
                          download_root=download_root,
+                         local_files_only=local_files_only,
                          cpu_threads=threads)
     if language is not None:
         tokenizer = faster_whisper.tokenizer.Tokenizer(model.hf_tokenizer, model.model.is_multilingual, task=task, language=language)

--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -278,7 +278,7 @@ def load_model(whisper_arch,
         language: str - The language of the model. (use English for now)
         model: Optional[WhisperModel] - The WhisperModel instance to use.
         download_root: Optional[str] - The root directory to download the model to.
-        local_files_only: Optional[bool] - If `True`, avoid downloading the file and return the path to the local cached file if it exists.
+        local_files_only: bool - If `True`, avoid downloading the file and return the path to the local cached file if it exists.
         threads: int - The number of cpu threads to use per worker, e.g. will be multiplied by num workers.
     Returns:
         A Whisper pipeline.


### PR DESCRIPTION
Adds the parameter local_files_only (default False for consistency) to whisperx.load_model so that the user can avoid downloading the file and return the path to the local cached file if it exists.