### PR TITLE
fix: force ctranslate to version 4.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 torch>=2
 torchaudio>=2
 faster-whisper==1.0.0
+ctranslate2==4.4.0
 transformers
 pandas
 setuptools>=65


### PR DESCRIPTION
Force ctranslate to version 4.4.0 due libcudnn_ops_infer.so.8: https://github.com/SYSTRAN/faster-whisper/issues/729