### PR TITLE
Adding progress output during diarization when print_progress=True

### DIFF
--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -218,7 +218,7 @@ def cli():
         results = []
         diarize_model = DiarizationPipeline(use_auth_token=hf_token, device=device)
         for result, input_audio_path in tmp_results:
-            diarize_segments = diarize_model(input_audio_path, min_speakers=min_speakers, max_speakers=max_speakers)
+            diarize_segments = diarize_model(input_audio_path, min_speakers=min_speakers, max_speakers=max_speakers, print_progress=print_progress)
             result = assign_word_speakers(diarize_segments, result)
             results.append((result, input_audio_path))
     # >> Write


### PR DESCRIPTION
This is a progress output when performing diarization.. I don't often code in Python so I'm looking any feedback is welcome.

Sample output:
~~~
>>Performing transcription...
Progress: 25.00%...
Progress: 50.00%...
Progress: 75.00%...
Progress: 100.00%...
>>Performing alignment...
Progress: 25.00%...
Progress: 50.00%...
Progress: 75.00%...
Progress: 100.00%...
>>Performing diarization...
>>Performing diarization segmentation...
Progress: 0.0%...
Progress: 35.56%...
Progress: 71.11%...
Progress: 106.67%...
Progress: 100.0%...
Progress: 100.0%...
>>Performing diarization speaker_counting...
Progress: 100.0%...
>>Performing diarization embeddings...
Progress: 0.0%...
Progress: 11.11%...
Progress: 22.22%...
Progress: 33.33%...
Progress: 44.44%...
Progress: 55.56%...
Progress: 66.67%...
Progress: 77.78%...
Progress: 88.89%...
Progress: 100.0%...
Progress: 100.0%...
>>Performing diarization discrete_diarization...
Progress: 100.0%...
~~~