### PR TITLE
feat: add basic installation test flow & restrict python versions

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -1,0 +1,32 @@
+name: Python Compatibility Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:  # Allows manual triggering from GitHub UI
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Test import
+        run: |
+          python -c "import whisperx; print('Successfully imported whisperx')"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version="3.2.0",
     description="Time-Accurate Automatic Speech Recognition using Whisper.",
     readme="README.md",
-    python_requires=">=3.8",
+    python_requires=">=3.9, <3.13",
     author="Max Bain",
     url="https://github.com/m-bain/whisperx",
     license="MIT",


### PR DESCRIPTION
This PR adds a very basic workflow to test the installation of whisperX on various Python versions. This is useful when modifying dependencies and bumping versions.

This PR also removes support for Python 3.8 which is officially EOL and unsupported by the pyannote.audio version we're using.