### PR TITLE
fix: add UTF-8 encoding when reading README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import pkg_resources
 from setuptools import find_packages, setup
 
-with open("README.md") as f:
+with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
## Description
Fixed UnicodeDecodeError when installing package on Windows systems by explicitly setting UTF-8 encoding when reading README.md file.

## Issue
When installing the package on Windows, the setup.py script fails with a UnicodeDecodeError because it tries to read README.md using the default system encoding (cp1252) which can't handle some special characters.

## Fix
Added explicit UTF-8 encoding when opening README.md file.