### PR TITLE
feat: include speaker information in  WriteTXT when diarizing

### DIFF
--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -214,7 +214,12 @@ class WriteTXT(ResultWriter):
 
     def write_result(self, result: dict, file: TextIO, options: dict):
         for segment in result["segments"]:
-            print(segment["text"].strip(), file=file, flush=True)
+            speaker = segment.get("speaker")
+            text = segment["text"].strip()
+            if speaker is not None:
+                print(f"[{speaker}]: {text}", file=file, flush=True)
+            else:
+                print(text, file=file, flush=True)
 
 
 class SubtitlesWriter(ResultWriter):


### PR DESCRIPTION
This PR adds the missing speaker tag for txt output in --diarize mode.

closes #801