### PR TITLE
Bug Fix: Suppress Numerals dataclasses replace method

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -1,6 +1,7 @@
 import os
 import warnings
 from typing import List, NamedTuple, Optional, Union
+from dataclasses import replace
 
 import ctranslate2
 import faster_whisper
@@ -240,7 +241,7 @@ class FasterWhisperPipeline(Pipeline):
             print(f"Suppressing numeral and symbol tokens")
             new_suppressed_tokens = numeral_symbol_tokens + self.options.suppress_tokens
             new_suppressed_tokens = list(set(new_suppressed_tokens))
-            self.options = self.options._replace(suppress_tokens=new_suppressed_tokens)
+            self.options = replace(self.options, suppress_tokens=new_suppressed_tokens)
 
         segments: List[SingleSegment] = []
         batch_size = batch_size or self._batch_size
@@ -269,7 +270,7 @@ class FasterWhisperPipeline(Pipeline):
 
         # revert suppressed tokens if suppress_numerals is enabled
         if self.suppress_numerals:
-            self.options = self.options._replace(suppress_tokens=previous_suppress_tokens)
+            self.options = replace(self.options, suppress_tokens=previous_suppress_tokens)
 
         return {"segments": segments, "language": language}
 


### PR DESCRIPTION
ISSUE: In faster_whisperer 1.1.0, TranscriptionOptions was changed from a NamedTuple to a Dataclass leading to a bug in .transcribe when using suppress_numerals. The bug arises with the self.options._replace method which does not exist for the dataclasses object.

FIX: Instead we can import replace from dataclasses and using that function instead allows us to update the transcriptionOptions and successfully transcribe. 



Error:
result = model.transcribe(audio, batch_size=self.batch_size, language=self.language)


File /anaconda/envs/w/lib/python3.10/site-packages/whisperx/asr.py:213, in FasterWhisperPipeline.transcribe(self, audio, batch_size, num_workers, language, task, chunk_size, print_progress, combined_progress, verbose)
    211     new_suppressed_tokens = numeral_symbol_tokens + self.options.suppress_tokens
    212     new_suppressed_tokens = list(set(new_suppressed_tokens))
--> 213     self.options = self.options._replace(suppress_tokens=new_suppressed_tokens)
    215 segments: List[SingleSegment] = []
    216 batch_size = batch_size or self._batch_size

AttributeError: 'TranscriptionOptions' object has no attribute '_replace'