### PR TITLE
Fix subtitle overlaps

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -306,6 +306,9 @@ def align(
         char_segments_arr = pd.DataFrame(char_segments_arr)
 
         aligned_subsegments = []
+        # sentecen offset in senconds to fix subtitle overlaps
+        sentence_start_offset = 0.03
+        sentence_end_offset = -0.02
         # assign sentence_idx to each character index
         char_segments_arr["sentence-idx"] = None
         for sdx2, (sstart, send) in enumerate(segment_data[sdx]["sentence_spans"]):
@@ -313,9 +316,9 @@ def align(
             char_segments_arr.loc[(char_segments_arr.index >= sstart) & (char_segments_arr.index <= send), "sentence-idx"] = sdx2
 
             sentence_text = text[sstart:send]
-            sentence_start = curr_chars["start"].min()
+            sentence_start = curr_chars["start"].min() + sentence_start_offset
             end_chars = curr_chars[curr_chars["char"] != ' ']
-            sentence_end = end_chars["end"].max()
+            sentence_end = end_chars["end"].max() + sentence_end_offset
             sentence_words = []
 
             for word_idx in curr_chars["word-idx"].unique():
@@ -335,9 +338,9 @@ def align(
                 word_segment = {"word": word_text}
 
                 if not np.isnan(word_start):
-                    word_segment["start"] = word_start
+                    word_segment["start"] = word_start + sentence_start_offset if not sentence_words else word_start
                 if not np.isnan(word_end):
-                    word_segment["end"] = word_end
+                    word_segment["end"] = word_end + sentence_end_offset if word_idx == len(curr_chars["word-idx"].unique()) - 1 else word_end
                 if not np.isnan(word_score):
                     word_segment["score"] = word_score
 


### PR DESCRIPTION
Hello,
This is a fix for subtitle overlaps that occurred after introducing [support for timestamps with numbers PR#986](https://github.com/m-bain/whisperX/pull/986).

In some cases, two subtitles could appear at the same time, as the figure below shows:

<img width="1443" alt="截屏2025-01-15 11 47 23" src="https://github.com/user-attachments/assets/49543c30-6e2e-41a6-a1b3-94769edacb4a" />

The last word is highlighted in the previous sentence (2nd line), and the first word is highlighted in the current sentence (1st line). 

To fix it, I add 0.03s to the start of the sentence and decrese 0.02s from the beginning of the sentence. 

