### PR TITLE
chore: handle empty segments_list case in silero

### DIFF
--- a/whisperx/vads/silero.py
+++ b/whisperx/vads/silero.py
@@ -59,4 +59,8 @@ class Silero(Vad):
                      offset: Optional[float] = None,
                      ):
         assert chunk_size > 0
+        if len(segments_list) == 0:
+            print("No active speech found in audio")
+            return []
+        assert segments_list, "segments_list is empty."
         return Vad.merge_chunks(segments, chunk_size, onset, offset)


### PR DESCRIPTION
When `vad_method=silero` and no active speech found in audio an `IndexError: list index out of range` occurs.
https://github.com/m-bain/whisperX/blob/355f8e06f7299e9761f16e7bf9e40ce9a05f2157/whisperx/vads/vad.py#L32

This repo handles empty segments_list case in silero with the style used in pyannote, preventing errors.
