### PR TITLE
chore: fix variable naming inconsistency from `segments` to `segments_list`

### DIFF
--- a/whisperx/vads/silero.py
+++ b/whisperx/vads/silero.py
@@ -53,7 +53,7 @@ class Silero(Vad):
         return audio
 
     @staticmethod
-    def merge_chunks(segments,
+    def merge_chunks(segments_list,
                      chunk_size,
                      onset: float = 0.5,
                      offset: Optional[float] = None,

--- a/whisperx/vads/silero.py
+++ b/whisperx/vads/silero.py
@@ -63,4 +63,4 @@ class Silero(Vad):
             print("No active speech found in audio")
             return []
         assert segments_list, "segments_list is empty."
-        return Vad.merge_chunks(segments, chunk_size, onset, offset)
+        return Vad.merge_chunks(segments_list, chunk_size, onset, offset)


### PR DESCRIPTION
Hello,
Correcting the previous error, the variable `segments` has been renamed to `segments_list` to maintain consistency across the codebase. For more context, please refer to the discussion in https://github.com/m-bain/whisperX/pull/1005.