### PR TITLE
 make sure the leading and tailing word boundary exists.

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -158,6 +158,13 @@ def align(
         else:
             per_word = text
 
+        # make sure the leading and tailing word boundary exists.
+        if model_lang not in LANGUAGES_WITHOUT_SPACES:
+            if not text.startswith(" "):
+                text = " " + text
+            if not text.endswith(" "):
+                text = text + " "
+
         clean_char, clean_cdx = [], []
         for cdx, char in enumerate(text):
             char_ = char.lower()


### PR DESCRIPTION
Fix https://github.com/m-bain/whisperX/issues/1016
On the [wav2vec alignment tutorial page](https://pytorch.org/audio/stable/tutorials/forced_alignment_tutorial.html), word boundary symbols are present at the beginning and end. During the whisperX alignment process, the tailing word boundary might be missing, causing the tailing silence to be absorbed into the last word. Adding the tailing word boundary would resolve this issue.
