### PR TITLE
Added Phoneme-Based ASR Model for Tagalog

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -70,6 +70,7 @@ DEFAULT_ALIGN_MODELS_HF = {
     "gl": "ifrz/wav2vec2-large-xlsr-galician",
     "ka": "xsway/wav2vec2-large-xlsr-georgian",
     "lv": "jimregan/wav2vec2-large-xlsr-latvian-cv",
+    "tl": "Khalsuu/filipino-wav2vec2-l-xls-r-300m-official",
 }
 
 


### PR DESCRIPTION
---

## **Phoneme-Based ASR Model for Tagalog**  

I noticed that there was no existing **phoneme-based ASR model** specifically for the **Tagalog language**, so I explored available models on **Hugging Face**. After testing one, I found that it performed well, providing **accurate timing from the segment level down to the word level**.  

### **Added Tagalog (tl - Filipino) Phoneme-Based ASR Model**  
🔗 **Model:**  [Khalsuu/filipino-wav2vec2-l-xls-r-300m-official](https://huggingface.co/Khalsuu/filipino-wav2vec2-l-xls-r-300m-official)

### **Testing Process**  
To evaluate the model’s performance, I tested it using a **YouTube video**:  
📺 **Video Link:** [Watch here](https://www.youtube.com/watch?v=RrbttqG6DX0)

I also developed a **Notebook** to convert the transcriptions into **SRT format** for further analysis.  

👾 **Alignment Preview:**  

![Alignment](https://github.com/user-attachments/assets/c3de0e66-fd33-44ed-aca4-30d7ebfcebaf)  

### **Output Evaluation**  
I tested the **SRT output** by overlaying it onto the video. The evaluation was conducted at different levels:  

🔹 **Word-Level Alignment:**  
> ![Word-Level](https://github.com/user-attachments/assets/6c4122fb-38b7-4e0c-867c-262df5bf1534)  

🔹 **Segment/Sentence/Utterance-Level Alignment:**  
> ![Segment-Level](https://github.com/user-attachments/assets/6f120c41-53ab-420d-a809-8f8c259bdc98)  

By the way, this is my **first pull request**, yay! So happy to contribute 🎉  

---