### PR TITLE
feat(hotwords): Pass hotwords option to faster-whisper

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -50,6 +50,7 @@ class WhisperModel(faster_whisper.WhisperModel):
             previous_tokens,
             without_timestamps=options.without_timestamps,
             prefix=options.prefix,
+            hotwords=options.hotwords
         )
 
         encoder_output = self.encode(features)


### PR DESCRIPTION
The hotwords argument exists but isn't passed to faster-whisper, this PR allows us to use hotwords