### PR TITLE
Fix for crash in alignment when called with no tokens

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -416,6 +416,8 @@ def get_wildcard_emission(frame_emission, tokens, blank_id):
         tensor: Maximum probability score for each token position
     """
     assert 0 <= blank_id < len(frame_emission)
+    if len(tokens) == 0:
+        return torch.tensor([])
 
     # Convert tokens to a tensor if they are not already
     tokens = torch.tensor(tokens) if not isinstance(tokens, torch.Tensor) else tokens


### PR DESCRIPTION
Fixes #1048

There are probably better ways to do this but this change restores previous behavior which worked before changes from 65b2332e139843cc553f589dc54e004e3c25ba39
 -> when called with empty list of tokens return empty tensor