### PR TITLE
Remove duplicated item

### DIFF
--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -106,7 +106,6 @@ LANGUAGES = {
     "jw": "javanese",
     "su": "sundanese",
     "yue": "cantonese",
-    "lv": "latvian",
 }
 
 # language code lookup by name, with a few language aliases


### PR DESCRIPTION
`utils.py` contains a duplicated dictionary item, which should be removed.
 
    "lv": "latvian"