### PR TITLE
Fix incorrect type annotations in get_writer function in utils.py

### DIFF
--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -410,7 +410,7 @@ class WriteJSON(ResultWriter):
 
 def get_writer(
     output_format: str, output_dir: str
-) -> Callable[[dict, TextIO, dict], None]:
+) -> Callable[[dict, str, dict], None]:
     writers = {
         "txt": WriteTXT,
         "vtt": WriteVTT,
@@ -425,7 +425,7 @@ def get_writer(
     if output_format == "all":
         all_writers = [writer(output_dir) for writer in writers.values()]
 
-        def write_all(result: dict, file: TextIO, options: dict):
+        def write_all(result: dict, file: str, options: dict):
             for writer in all_writers:
                 writer(result, file, options)
 


### PR DESCRIPTION
I noticed the following issue while trying to use WhisperX's output writing capabilities from within python code for my own project called Project-W. It is not exactly major however it results in my IDE complaining about incorrect types when calling the output of `get_writer` with a string as the second attribute. If I pass a TextIO instead as the type annotation suggests it fails. Here the more in-depth explanation:

The `get_writer` function returns a Callable which is currently annotated as follows: `Callable[[dict, TextIO, dict], None]`.
`get_writer` then returns instances of writers (e.g. `WriteJSON`, `WriteSRT`) which all inherit from `ResultWriter`. The `__call__` method of `ResultWriter` however is annotated like this: `def __call__(self, result: dict, audio_path: str, options: dict):`. These two annotations contradict each other because the `__call__` method takes a `str` as the second argument while `get_writer` claims to return a callable which takes a `TextIO` as the second argument.

The type annotation of the `__call__` method of `ResultWriter` is correct since the method expects a string to construct the os path, hence this PR adjusts the annotation in `get_writer` to fit the one of `ResultWriter`.