### PR TITLE
Fix: Ensure integer tensor indexing in get_wildcard_emission() to avoid IndexError

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -424,7 +424,7 @@ def get_wildcard_emission(frame_emission, tokens, blank_id):
     wildcard_mask = (tokens == -1)
 
     # Get scores for non-wildcard positions
-    regular_scores = frame_emission[tokens.clamp(min=0)]  # clamp to avoid -1 index
+    regular_scores = frame_emission[tokens.clamp(min=0).long()]  # clamp to avoid -1 index
 
     # Create a mask and compute the maximum value without modifying frame_emission
     max_valid_score = frame_emission.clone()   # Create a copy


### PR DESCRIPTION
**Bug Fix: IndexError in `alignment.py` when running alignment**

**Problem**
Sometimes when running alignment with WhisperX, I got this error:
```shell
IndexError: tensors used as indices must be long, int, byte or bool tensors
```

This happens in `alignment.py` at line 427:
```python
regular_scores = frame_emission[tokens.clamp(min=0)]
```
Looks like tokens can sometimes be a float tensor, but PyTorch only accepts integer types for indexing.

**How I fixed it**
I just added `.long()` to make sure it’s using integer indices:
```python
regular_scores = frame_emission[tokens.clamp(min=0).long()]
```
Pretty small change, but it fixes the crash.

**Notes**
- This bug is **intermittent** — doesn’t happen all the time.
- I ran into it while transcribing a Chinese audio file using `large-v2`.
- After the fix, the alignment step runs fine without errors.