### PR TITLE
Update README.md to include --device cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To label the transcript with speaker ID's (set number of speakers if known e.g. 
 
 To run on CPU instead of GPU (and for running on Mac OS X):
 
-    whisperx path/to/audio.wav --compute_type int8
+    whisperx path/to/audio.wav --compute_type int8 --device cpu
 
 ### Other languages
 


### PR DESCRIPTION
Based on this: https://github.com/m-bain/whisperX/issues/748

I am not sure if on OS X, only CPU is possible or if this should be split into too (ie. how to run on OS X and how to run on CPU). Without `--device cpu`, I was getting the libcudnn8 error, so it was still trying to run on GPU.