### PR TITLE
allow passing in num_speakers via cli

### DIFF
--- a/whisperx/__main__.py
+++ b/whisperx/__main__.py
@@ -43,6 +43,7 @@ def cli():
     parser.add_argument("--diarize", action="store_true", help="Apply diarization to assign speaker labels to each segment/word")
     parser.add_argument("--min_speakers", default=None, type=int, help="Minimum number of speakers to in audio file")
     parser.add_argument("--max_speakers", default=None, type=int, help="Maximum number of speakers to in audio file")
+    parser.add_argument("--num_speakers", default=None, type=int, help="Exact number of speakers in audio file")
     parser.add_argument("--diarize_model", default="pyannote/speaker-diarization-3.1", type=str, help="Name of the speaker diarization model to use")
 
     parser.add_argument("--temperature", type=float, default=0, help="temperature to use for sampling")

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -57,6 +57,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
     diarize: bool = args.pop("diarize")
     min_speakers: int = args.pop("min_speakers")
     max_speakers: int = args.pop("max_speakers")
+    num_speakers: int = args.pop("num_speakers")
     diarize_model_name: str = args.pop("diarize_model")
     print_progress: bool = args.pop("print_progress")
 
@@ -210,7 +211,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
         diarize_model = DiarizationPipeline(model_name=diarize_model_name, use_auth_token=hf_token, device=device)
         for result, input_audio_path in tmp_results:
             diarize_segments = diarize_model(
-                input_audio_path, min_speakers=min_speakers, max_speakers=max_speakers
+                input_audio_path, min_speakers=min_speakers, max_speakers=max_speakers, num_speakers=num_speakers
             )
             result = assign_word_speakers(diarize_segments, result)
             results.append((result, input_audio_path))


### PR DESCRIPTION
I'm running into issues with diarization when using both `min_speakers` and `max_speakers` as the same value (2). I'm currently triggering the pipeline via the CLI and it would be great if I could similarly pass in `num_speakers` to be able to compare how that performs. 

I didn't test this change as I haven't gotten this project setup on my local machine, but with it being such a small change I figured I'd go ahead and submit the PR. Please let me know if you'd like any changes. 