### PR TITLE
Fix Tensor IndexError with Type Casting in alignment.py

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -424,7 +424,8 @@ def get_wildcard_emission(frame_emission, tokens, blank_id):
     wildcard_mask = (tokens == -1)
 
     # Get scores for non-wildcard positions
-    regular_scores = frame_emission[tokens.clamp(min=0)]  # clamp to avoid -1 index
+    clamped_tokens = tokens.tokens.clamp(min=0).long() # clamp to avoid -1 index and ensure long data type.
+    regular_scores = frame_emission[clamped_tokens] 
 
     # Create a mask and compute the maximum value without modifying frame_emission
     max_valid_score = frame_emission.clone()   # Create a copy


### PR DESCRIPTION
### What
Addresses an `IndexError` in `get_wildcard_emission` (alignment.py) when
`tokens` is not an integer dtype.

### Why
Only integer-typed tensors (`LongTensor`, etc.) can be used for indexing.
Without this fix, word-level alignment will crash on float32 token tensors.

### How
In `alignment.py`, before indexing, do:
  ```python
  clamped_tokens = tokens.clamp(min=0).long()
  regular_scores = frame_emission[clamped_tokens]
  ```
  
Closes m-bain/whisperX#1048
Closes m-bain/whisperX#1173