### PR TITLE
Update utils.py

### DIFF
--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import zlib
+from pathlib import Path
 from typing import Callable, Optional, TextIO
 
 LANGUAGES = {
@@ -198,9 +199,8 @@ class ResultWriter:
     def __call__(self, result: dict, audio_path: str, options: dict):
         audio_basename = os.path.basename(audio_path)
         audio_basename = os.path.splitext(audio_basename)[0]
-        output_path = os.path.join(
-            self.output_dir, audio_basename + "." + self.extension
-        )
+        output_path = Path(self.output_dir).joinpath(audio_basename + "." + self.extension)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
         with open(output_path, "w", encoding="utf-8") as f:
             self.write_result(result, file=f, options=options)


### PR DESCRIPTION
fix: use pathlib to replace os.path.join

Fix the weird error on Windows:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "$HOME\AppData\Local\Programs\Python\Python312\Scripts\whisperx.exe\__main__.py", line 7, in <module>
  File "$HOME\AppData\Local\Programs\Python\Python312\Lib\site-packages\whisperx\__main__.py", line 85, in cli
    transcribe_task(args, parser)
  File "$HOME\AppData\Local\Programs\Python\Python312\Lib\site-packages\whisperx\transcribe.py", line 234, in transcribe_task
    writer(result, audio_path, writer_args)
  File "$HOME\AppData\Local\Programs\Python\Python312\Lib\site-packages\whisperx\utils.py", line 205, in __call__
    with open(output_path, "w+", encoding="utf-8") as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '.\\sample.srt'
```