### PR TITLE
Changed __init__.py to allow better hinting

### DIFF
--- a/whisperx/__init__.py
+++ b/whisperx/__init__.py
@@ -1,31 +1,12 @@
-import importlib
+from whisperx.alignment import load_align_model, align
+from whisperx.asr import load_model
+from whisperx.audio import load_audio
+from whisperx.diarize import assign_word_speakers
 
-
-def _lazy_import(name):
-    module = importlib.import_module(f"whisperx.{name}")
-    return module
-
-
-def load_align_model(*args, **kwargs):
-    alignment = _lazy_import("alignment")
-    return alignment.load_align_model(*args, **kwargs)
-
-
-def align(*args, **kwargs):
-    alignment = _lazy_import("alignment")
-    return alignment.align(*args, **kwargs)
-
-
-def load_model(*args, **kwargs):
-    asr = _lazy_import("asr")
-    return asr.load_model(*args, **kwargs)
-
-
-def load_audio(*args, **kwargs):
-    audio = _lazy_import("audio")
-    return audio.load_audio(*args, **kwargs)
-
-
-def assign_word_speakers(*args, **kwargs):
-    diarize = _lazy_import("diarize")
-    return diarize.assign_word_speakers(*args, **kwargs)
+__all__ = [
+    "load_align_model",
+    "align",
+    "load_model",
+    "load_audio",
+    "assign_word_speakers"
+]


### PR DESCRIPTION
As `__init__.py` is currently written, the functions available directly from `whisper` don't allow for hinting to reach through directly to the typing and doc strings:

<img width="381" height="71" alt="Screenshot 2025-08-05 at 11 14 16 AM" src="https://github.com/user-attachments/assets/b9e27f06-b594-488e-b9be-84df089863c5" />

This rewritten version enables access to typing and docstrings:

<img width="788" height="391" alt="Screenshot 2025-08-05 at 11 16 17 AM" src="https://github.com/user-attachments/assets/85297b8b-b29f-4533-b736-292f245958aa" />
