### PR TITLE
Fix IndexError in alignment.py when token id == vocab size (clamp upper bound)

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -415,8 +415,6 @@ def get_wildcard_emission(frame_emission, tokens, blank_id):
     Returns:
         tensor: Maximum probability score for each token position
     """
-    assert 0 <= blank_id < len(frame_emission)
-
     # Convert tokens to a tensor if they are not already
     tokens = torch.tensor(tokens) if not isinstance(tokens, torch.Tensor) else tokens
 
@@ -424,7 +422,6 @@ def get_wildcard_emission(frame_emission, tokens, blank_id):
     wildcard_mask = (tokens == -1)
 
     # Get scores for non-wildcard positions
-    ### Patched by uduntuntu 2025-08-24
     # regular_scores = frame_emission[tokens.clamp(min=0).long()]  # clamp to avoid -1 index
     V = frame_emission.size(0)
     assert V > 0 and 0 <= blank_id < V, "empty emissions or invalid blank_id"

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -416,6 +416,8 @@ def get_wildcard_emission(frame_emission, tokens, blank_id):
         tensor: Maximum probability score for each token position
     """
     assert 0 <= blank_id < len(frame_emission)
+    if len(tokens) == 0:
+        return torch.tensor([])
 
     # Convert tokens to a tensor if they are not already
     tokens = torch.tensor(tokens) if not isinstance(tokens, torch.Tensor) else tokens


### PR DESCRIPTION
Reproduction on Finnish with alignment showed IndexError: index X is out of bounds for dimension 0 with size V.

Cause: only lower bound was clamped (min=0), so token==V indexed out of range.

Fix: clamp tokens to [0, V-1] and assert valid blank_id/non-empty emissions.

Included minimal repro script and observed OK results after patch.

```
# Run (in virtualenv):  python test_alignment_out_of_bounds.py
import torch
from whisperx import alignment as A

def run_case(V, tokens, blank_id=0, label=""):
    fe = torch.randn(V, dtype=torch.float32)
    t = torch.tensor(tokens, dtype=torch.long)
    try:
        out = A.get_wildcard_emission(fe, t, blank_id)
        ok = bool(torch.isfinite(out).all())
        print(f"[OK ] {label:40s} -> out.shape={tuple(out.shape)} finite={ok}")
    except Exception as e:
        print(f"[ERR] {label:40s} -> {type(e).__name__}: {e}")

print("Testing whisperx.alignment.get_wildcard_emission")
print("Function:", A.get_wildcard_emission.__code__.co_filename)

# OFF-BY-ONE repro: token == vocab size (V)
run_case(34, [34], 0, "off-by-one (V=34, token=V)")

# Mixed case: wildcard + valid + token==V
run_case(34, [-1, 0, 5, 34], 0, "wildcard + in-range + token=V")

# Edge case: empty emissions (should assert / error, but not IndexError from indexing)
run_case(0, [0], 0, "empty emissions (V=0)")
```
