### PR TITLE
feat: use pre-trained Punkt model instead of empty parameters

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -22,9 +22,8 @@ from whisperx.types import (
     SingleWordSegment,
     SegmentData,
 )
-from nltk.tokenize.punkt import PunktSentenceTokenizer, PunktParameters
-
-PUNKT_ABBREVIATIONS = ['dr', 'vs', 'mr', 'mrs', 'prof', 'jr', 'sr', 'ph.d']
+import nltk
+from nltk.data import load as nltk_load
 
 LANGUAGES_WITHOUT_SPACES = ["ja", "zh"]
 
@@ -188,9 +187,11 @@ def align(
                 clean_wdx.append(wdx)
 
 
-        punkt_param = PunktParameters()
-        punkt_param.abbrev_types = set(PUNKT_ABBREVIATIONS)
-        sentence_splitter = PunktSentenceTokenizer(punkt_param)
+        try:
+            sentence_splitter = nltk_load('tokenizers/punkt/english.pickle')
+        except LookupError:
+            nltk.download('punkt_tab', quiet=True)
+            sentence_splitter = nltk_load('tokenizers/punkt/english.pickle')
         sentence_spans = list(sentence_splitter.span_tokenize(text))
 
         segment_data[sdx] = {


### PR DESCRIPTION
## Problem
The alignment code was creating an empty `PunktParameters()` object and only setting a few hardcoded abbreviations, which bypassed all of NLTK Punkt's pre-trained model. This could cause incorrect sentence splitting (e.g., "Richard Jr." | "went home" instead of "Richard Jr. went home"),leading to alignment failures and inaccurate word-level timestamps.


## Solution
Use Punkt's pre-trained English model with all it's abbreviations and trained sentence boundary detection.


> [!NOTE]
Currently uses English Punkt model for all languages. Could be improved with language-specific models.