### PR TITLE
 chore: refine triton dependency to restrict installation to x86_64 Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 urls = { repository = "https://github.com/m-bain/whisperx" }
 authors = [{ name = "Max Bain" }]
 name = "whisperx"
-version = "3.7.1"
+version = "3.7.2"
 description = "Time-Accurate Automatic Speech Recognition using Whisper."
 readme = "README.md"
 requires-python = ">=3.9, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -4006,7 +4006,7 @@ wheels = [
 
 [[package]]
 name = "whisperx"
-version = "3.7.1"
+version = "3.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
While resolving #1257 I realized that triton only has wheels for x86_64 on linux, which would cause the same install issues.