### PR TITLE
Allow to use a plain-text transcription file as a reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you’re looking for a transcription API for meetings, consider checking out 
   </a>
   <a href="https://twitter.com/intent/tweet?text=&url=https%3A%2F%2Fgithub.com%2Fm-bain%2FwhisperX">
   <img src="https://img.shields.io/twitter/url/https/github.com/m-bain/whisperX.svg?style=social" alt="Twitter">
-  </a>      
+  </a>
 </p>
 
 <img width="1216" align="center" alt="whisperx-arch" src="https://raw.githubusercontent.com/m-bain/whisperX/refs/heads/main/figures/pipeline.png">
@@ -145,6 +145,10 @@ To label the transcript with speaker ID's (set number of speakers if known e.g. 
 To run on CPU instead of GPU (and for running on Mac OS X):
 
     whisperx path/to/audio.wav --compute_type int8 --device cpu
+
+To synchronize a plain-text transcription file on the computed transcription (add `--log-level=debug` to get details on how the transcription was translated):
+
+    whisperx path/to/audio.wav --text_file lyrics.txt
 
 ### Other languages
 

--- a/whisperx/__main__.py
+++ b/whisperx/__main__.py
@@ -34,6 +34,7 @@ def cli():
     parser.add_argument("--interpolate_method", default="nearest", choices=["nearest", "linear", "ignore"], help="For word .srt, method to assign timestamps to non-aligned words, or merge them into neighbouring.")
     parser.add_argument("--no_align", action='store_true', help="Do not perform phoneme alignment")
     parser.add_argument("--return_char_alignments", action='store_true', help="Return character-level alignments in the output json file")
+    parser.add_argument("--text_file", type=str, default=None, help="Transcription plain-text file to use as reference.")
 
     # vad params
     parser.add_argument("--vad_method", type=str, default="pyannote", choices=["pyannote", "silero"], help="VAD method to be used")

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -1,12 +1,13 @@
 import argparse
 import gc
 import os
+from pathlib import Path
 import warnings
 
 import numpy as np
 import torch
 
-from whisperx.alignment import align, load_align_model
+from whisperx.alignment import align, align_text, load_align_model
 from whisperx.asr import load_model
 from whisperx.audio import load_audio
 from whisperx.diarize import DiarizationPipeline, assign_word_speakers
@@ -49,6 +50,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
         no_align = True
 
     return_char_alignments: bool = args.pop("return_char_alignments")
+    text_file: str = args.pop("text_file")
 
     hf_token: str = args.pop("hf_token")
     vad_method: str = args.pop("vad_method")
@@ -196,6 +198,8 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
                     return_char_alignments=return_char_alignments,
                     print_progress=print_progress,
                 )
+                if text_file:
+                    result = align_text(result, Path(text_file))
 
             results.append((result, audio_path))
 
@@ -217,9 +221,9 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
         diarize_model = DiarizationPipeline(model_name=diarize_model_name, use_auth_token=hf_token, device=device)
         for result, input_audio_path in tmp_results:
             diarize_result = diarize_model(
-                input_audio_path, 
-                min_speakers=min_speakers, 
-                max_speakers=max_speakers, 
+                input_audio_path,
+                min_speakers=min_speakers,
+                max_speakers=max_speakers,
                 return_embeddings=return_speaker_embeddings
             )
 


### PR DESCRIPTION
This PR adds the `--text_file` CLI option, which can be used to set a plain-text transcription file as a reference. It can be used for instance to generate karaoke subtitles, assuming you have the lyrics (usually available on the web).

This step is performed after the alignment. It's based on the new `align_text` function, which takes an aligned transcription result and a file path, and return an other aligned transcription result. It tries match words between synchronized transcription and plain-text transcription using the [Python difflib module](https://docs.python.org/3/library/difflib.html), acting similarly to a git diff. The diff is done on a slugified version oh each word (so `Hëllo` matches with `hellô!`).

Start and end-time are transferred as-is when possible, otherwise they are based on last/previous times and word lengths. Word scores are also transferred.

If the logger is set to DEBUG, it prints the details on how each word is converted, with colors to distinguish diff operations (equal / replace / insert / delete):

<img width="1110" height="596" alt="image" src="https://github.com/user-attachments/assets/30caea38-f170-4f88-9308-2da112a0dcf4" />

Here with an extract of *Les filles, les meufs* from french singer Marguerite.

It was quite a journey to work on this, I hope it will be useful for some people. :)