### PR TITLE
Fix: Add Windows (AMD64) GPU support for PyTorch installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,13 +42,15 @@ include = ["whisperx*"]
 [tool.uv.sources]
 torch = [
   { index = "pytorch-cpu", marker = "sys_platform == 'darwin'" },
-  { index = "pytorch-cpu", marker = "platform_machine != 'x86_64' and sys_platform != 'darwin'" },
-  { index = "pytorch", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+  { index = "pytorch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+  { index = "pytorch", marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
+  { index = "pytorch-cpu", marker = "platform_machine != 'x86_64' and platform_machine != 'AMD64'" },
 ]
 torchaudio = [
   { index = "pytorch-cpu", marker = "sys_platform == 'darwin'" },
-  { index = "pytorch-cpu", marker = "platform_machine != 'x86_64' and sys_platform != 'darwin'" },
-  { index = "pytorch", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+  { index = "pytorch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+  { index = "pytorch", marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
+  { index = "pytorch-cpu", marker = "platform_machine != 'x86_64' and platform_machine != 'AMD64'" },
 ]
 triton = [
   { index = "pytorch", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
**Problem**:

Windows systems with NVIDIA GPUs are currently installing CPU-only PyTorch instead of CUDA-enabled PyTorch, making GPU acceleration unavailable on Windows.
Root cause: Windows reports platform_machine == 'AMD64' instead of 'x86_64', causing the existing marker conditions to fail.

**Changes**:

More explicit Linux condition: platform_machine == 'x86_64' and sys_platform == 'linux' (instead of sys_platform != 'darwin')
New Windows condition: platform_machine == 'AMD64' and sys_platform == 'win32' → routes Windows to CUDA
Fixed fallback condition: platform_machine != 'x86_64' and platform_machine != 'AMD64' → excludes both x86_64 variants

**Key improvements**:

1. More explicit Linux condition: sys_platform == 'linux' instead of != 'darwin' to avoid ambiguity
2. New Windows CUDA condition: platform_machine == 'AMD64' and sys_platform == 'win32'
3. Fixed fallback: Excludes both 'x86_64' and 'AMD64' to prevent Windows from falling through to CPU

The same changes apply to torchaudio sources.

**Testing**:

Tested on Windows 11

`uv run python -c "import sys, platform; print(f'Platform: {sys.platform}'); print(f'Machine: {platform.machine()}')"`

Platform: win32
Machine: AMD64

**Before**:
`uv run python -c "import torch; print(f'Torch version: {torch.__version__}'); print(f'CUDA available: {torch.cuda.is_available()}')"`

Torch version: 2.8.0+cpu
CUDA available: False

**After**:
`uv run python -c "import torch; print(f'Torch version: {torch.__version__}'); print(f'CUDA available: {torch.cuda.is_available()}')"`

Torch version: 2.8.0+cu128
CUDA available: True

**Validation**: Successfully transcribed a 40-minute demo video using GPU acceleration.

**Info**: I didn't know if you want me to update the uv.lock file as well or just recompile it urself I can do that any time!
Thank you very much for your great work!