### PR TITLE
 fix: pin huggingface-hub<1.0.0 for pyannote-audio compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 urls = { repository = "https://github.com/m-bain/whisperx" }
 authors = [{ name = "Max Bain" }]
 name = "whisperx"
-version = "3.7.4"
+version = "3.7.5"
 description = "Time-Accurate Automatic Speech Recognition using Whisper."
 readme = "README.md"
 requires-python = ">=3.9, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -4016,7 +4016,7 @@ wheels = [
 
 [[package]]
 name = "whisperx"
-version = "3.7.4"
+version = "3.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
This PR pins huggingface-hub<1.0.0 to prevent the use_auth_token removal. Merely updating the arguments as seen in other PR's is not enough because the dependencies are also incompatible.