### PR TITLE
Pass model_dir when initialising diarization model

### DIFF
--- a/whisperx/diarize.py
+++ b/whisperx/diarize.py
@@ -17,12 +17,13 @@ class DiarizationPipeline:
         model_name=None,
         use_auth_token=None,
         device: Optional[Union[str, torch.device]] = "cpu",
+        model_dir: Optional[str] = None,
     ):
         if isinstance(device, str):
             device = torch.device(device)
         model_config = model_name or "pyannote/speaker-diarization-3.1"
         logger.info(f"Loading diarization model: {model_config}")
-        self.model = Pipeline.from_pretrained(model_config, use_auth_token=use_auth_token).to(device)
+        self.model = Pipeline.from_pretrained(model_config, use_auth_token=use_auth_token, cache_dir=model_dir).to(device)
 
     def __call__(
         self,

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -214,7 +214,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
         logger.info("Performing diarization...")
         logger.info(f"Using model: {diarize_model_name}")
         results = []
-        diarize_model = DiarizationPipeline(model_name=diarize_model_name, use_auth_token=hf_token, device=device)
+        diarize_model = DiarizationPipeline(model_name=diarize_model_name, use_auth_token=hf_token, device=device, model_dir=model_dir)
         for result, input_audio_path in tmp_results:
             diarize_result = diarize_model(
                 input_audio_path, 


### PR DESCRIPTION
The `Pipeline.from_pretrained` function call supports passing through cache_dir: https://github.com/pyannote/pyannote-audio/blob/6328b97b9489e1b6ae99f586df01c1c6fcac8b82/src/pyannote/audio/core/pipeline.py#L142

I think it makes sense to pass through model_dir so that it's consistent for diarization models as well as transcription.

I initially made this change in order to ensure that diarization works offline if the models have already been cached, but discovered that setting HF_HUB_OFFLINE (https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfhuboffline) achieves that. 

I tested this locally and verified transcription still works