### PR TITLE
Fix: pass no_repeat_ngram_size and repetition_penalty to CTranslate2 generate()

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -72,6 +72,8 @@ class WhisperModel(faster_whisper.WhisperModel):
                 max_length=self.max_length,
                 suppress_blank=options.suppress_blank,
                 suppress_tokens=options.suppress_tokens,
+                no_repeat_ngram_size=options.no_repeat_ngram_size,
+                repetition_penalty=options.repetition_penalty,
             )
 
         tokens_batch = [x.sequences_ids[0] for x in result]


### PR DESCRIPTION
## Problem

`generate_segment_batched()` in `WhisperModel` does not forward `no_repeat_ngram_size` and `repetition_penalty` from `TranscriptionOptions` to the underlying `ctranslate2.Whisper.generate()` call.

These two parameters are already accepted by CTranslate2's `generate()` method and are already stored in `TranscriptionOptions`, but the batched inference path simply never passes them through. This means that even if a user sets `repetition_penalty=1.3` and `no_repeat_ngram_size=3` in `asr_options`, they have zero effect during batched transcription.

This is especially problematic for noisy audio (phone calls, low-bitrate recordings, hold music) where Whisper tends to produce repetition loops repeated dozens of times in a single segment.

### What this PR does

Adds the two missing keyword arguments to the `self.model.generate()` call inside `generate_segment_batched()`:

```python
result = self.model.generate(
    encoder_output,
    [prompt] * batch_size,
    beam_size=options.beam_size,
    patience=options.patience,
    length_penalty=options.length_penalty,
    max_length=self.max_length,
    suppress_blank=options.suppress_blank,
    suppress_tokens=options.suppress_tokens,
    no_repeat_ngram_size=options.no_repeat_ngram_size,   # added
    repetition_penalty=options.repetition_penalty,        # added
)
```

No other changes. No new dependencies. Fully backward compatible since both parameters default to values that produce no behavioral change (`no_repeat_ngram_size=0`, `repetition_penalty=1`).

### Note on other TranscriptionOptions parameters

Several other options such as `compression_ratio_threshold`, `log_prob_threshold`, `no_speech_threshold`, `hallucination_silence_threshold`, and temperature fallback are also stored in `TranscriptionOptions` but not used in the batched path. These cannot be passed to `ctranslate2.generate()` because they are post-generation filtering logic implemented in faster-whisper's `transcribe()` method. Adding them would require a larger refactor of the batched pipeline. This PR focuses only on the two parameters that CTranslate2 natively supports.