### PR TITLE
feat: expose avg_logprob per segment from ctranslate2 beam search

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -216,6 +216,7 @@ def align(
         t1 = segment["start"]
         t2 = segment["end"]
         text = segment["text"]
+        avg_logprob = segment.get("avg_logprob")
 
         aligned_seg: SingleAlignedSegment = {
             "start": t1,
@@ -224,6 +225,9 @@ def align(
             "words": [],
             "chars": None,
         }
+
+        if avg_logprob is not None:
+            aligned_seg["avg_logprob"] = avg_logprob
 
         if return_char_alignments:
             aligned_seg["chars"] = []
@@ -353,12 +357,15 @@ def align(
 
                 sentence_words.append(word_segment)
 
-            aligned_subsegments.append({
+            subsegment = {
                 "text": sentence_text,
                 "start": sentence_start,
                 "end": sentence_end,
                 "words": sentence_words,
-            })
+            }
+            if avg_logprob is not None:
+                subsegment["avg_logprob"] = avg_logprob
+            aligned_subsegments.append(subsegment)
 
             if return_char_alignments:
                 curr_chars = curr_chars[["char", "start", "end", "score"]]
@@ -376,6 +383,8 @@ def align(
             agg_dict["text"] = "".join
         if return_char_alignments:
             agg_dict["chars"] = "sum"
+        if avg_logprob is not None:
+            agg_dict["avg_logprob"] = "first"
         aligned_subsegments= aligned_subsegments.groupby(["start", "end"], as_index=False).agg(agg_dict)
         aligned_subsegments = aligned_subsegments.to_dict('records')
         aligned_segments += aligned_subsegments

--- a/whisperx/schema.py
+++ b/whisperx/schema.py
@@ -1,5 +1,10 @@
 from typing import TypedDict, Optional, List, Tuple
 
+try:
+    from typing import NotRequired
+except ImportError:
+    from typing_extensions import NotRequired
+
 
 class SingleWordSegment(TypedDict):
     """
@@ -28,6 +33,7 @@ class SingleSegment(TypedDict):
     start: float
     end: float
     text: str
+    avg_logprob: NotRequired[float]
 
 
 class SegmentData(TypedDict):
@@ -49,6 +55,7 @@ class SingleAlignedSegment(TypedDict):
     start: float
     end: float
     text: str
+    avg_logprob: NotRequired[float]
     words: List[SingleWordSegment]
     chars: Optional[List[SingleCharSegment]]
 


### PR DESCRIPTION
## Summary

Expose per-segment `avg_logprob` through the full pipeline, giving downstream consumers a confidence score to filter hallucinated or low-quality segments.

- Add `avg_logprob` as `NotRequired[float]` to `SingleSegment` and `SingleAlignedSegment` schemas
- Preserve backward compatibility: segments without `avg_logprob` pass through alignment unchanged

Supersedes #413, which extracted `avg_logprob` during transcription but could not propagate it through alignment.


## Details

`avg_logprob` is recovered from ctranslate2's length-normalized score by reversing the normalization and dividing by total token count (including EOS), matching faster-whisper's own implementation:

```python
seq_len = len(res.sequences_ids[0])
cum_logprob = res.scores[0] * (seq_len ** options.length_penalty)
avg_logprob = cum_logprob / (seq_len + 1)
```

During alignment, when segments are split into sentences, each sub-segment inherits the `avg_logprob` of its parent.

## Testing

Verified on Google Colab (GPU, `device=cuda`, `compute_type=float16`, model `tiny`):

1. confirmed the reverse-normalization formula produces identical values to faster-whisper's native `segment.avg_logprob` across varying sequence lengths
2. `avg_logprob` is present, float, and negative on all segments returned by `whisperx.load_model().transcribe()`
3. `avg_logprob` values survive `whisperx.align()` unchanged, correctly inherited by sub-segments after sentence splitting
4. segments without `avg_logprob` (legacy input) pass through alignment with no errors


Closes #485, closes #194, supersedes #413.