### PR TITLE
feat: forward --hf_token to WhisperModel for gated/private model support

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -314,6 +314,7 @@ def load_model(
     download_root: Optional[str] = None,
     local_files_only=False,
     threads=4,
+    use_auth_token: Optional[Union[str, bool]] = None,
 ) -> FasterWhisperPipeline:
     """Load a Whisper model for inference.
     Args:
@@ -341,7 +342,8 @@ def load_model(
                          compute_type=compute_type,
                          download_root=download_root,
                          local_files_only=local_files_only,
-                         cpu_threads=threads)
+                         cpu_threads=threads,
+                         use_auth_token=use_auth_token)
     if language is not None:
         tokenizer = Tokenizer(model.hf_tokenizer, model.model.is_multilingual, task=task, language=language)
     else:

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -141,6 +141,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
         task=task,
         local_files_only=model_cache_only,
         threads=faster_whisper_threads,
+        use_auth_token=hf_token,
     )
 
     for audio_path in args.pop("audio"):


### PR DESCRIPTION
## Summary

- Add `use_auth_token` parameter to `load_model()` and pass it through to faster-whisper's `WhisperModel`
- Wire the existing `--hf_token` CLI argument to `load_model()`, so a single token handles both Whisper model download and diarization

This enables loading gated or private HuggingFace models without requiring `huggingface-cli login`

Closes #1068
Supersedes #1172
