### PR TITLE
fix: revert #986 wildcard alignment that broke word-level timestamps (#1220)

### DIFF
--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -399,7 +399,7 @@ def get_trellis(emission, tokens, blank_id=0):
     # The extra dim for time axis is for simplification of the code.
     trellis = torch.empty((num_frame + 1, num_tokens + 1))
     trellis[0, 0] = 0
-    trellis[1:, 0] = torch.cumsum(emission[:, 0], 0)
+    trellis[1:, 0] = torch.cumsum(emission[:, blank_id], 0)
     trellis[0, -num_tokens:] = -float("inf")
     trellis[-num_tokens:, 0] = float("inf")
 
@@ -442,7 +442,7 @@ def backtrack(trellis, emission, tokens, blank_id=0):
         changed = trellis[t - 1, j - 1] + emission[t - 1, tokens[j - 1]]
 
         # 2. Store the path with frame-wise probability.
-        prob = emission[t - 1, tokens[j - 1] if changed > stayed else 0].exp().item()
+        prob = emission[t - 1, tokens[j - 1] if changed > stayed else blank_id].exp().item()
         # Return token index and time index in non-trellis coordinate.
         path.append(Point(j - 1, t - 1, prob))
 


### PR DESCRIPTION
## Problem

Word-level timestamps have been incorrect since v3.3.3 (#986, "support timestamps for numbers"). Segments spread across the full window instead of anchoring to actual speech — visible in every version from v3.3.3 to v3.8.1.

Reproduced with the alignment-only API (user-provided transcript + padded segment boundaries), confirmed correct on v3.3.0.

## Root cause

#986 introduced three interrelated changes that together broke CTC alignment:

1. **Wildcards** — unknown chars (numbers, punctuation) became `*` placeholders mapped to token `-1`. `get_wildcard_emission()` scored these with `torch.max()` over all non-blank emissions, greedily matching any speech-like signal in the window.
2. **`get_trellis` rewrite** — shape changed from `(num_frame+1, num_tokens+1)` to `(num_frame, num_tokens)`, discarding the SoS-offset design from the PyTorch forced alignment tutorial.
3. **`backtrack_beam` replacement** — always starts backtracking from the last frame of the segment window. The original `backtrack()` used `torch.argmax()` on the last token column to find the starting frame. With padded boundaries (silence before/after speech), the new implementation spread all tokens across the full window, placing the first word in the silence.

## Fix

Restores the original PyTorch tutorial implementation:

- Unknown chars are skipped; words with only unknown chars become unalignable (handled by `interpolate_nans`, documented behaviour)
- `get_trellis`: restored `(num_frame+1, num_tokens+1)` shape with SoS offset
- `backtrack`: restored `torch.argmax`-based starting frame
- Removed `backtrack_beam`, `get_wildcard_emission`, `BeamState`, `Path`
- `blank_id` parameter now used consistently instead of hardcoded `0` (separate commit)


Closes #1220
