### PR TITLE
Fix/1368 interpolate ignore

### DIFF
--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -468,7 +468,6 @@ def get_writer(
     return writers[output_format](output_dir)
 
 def interpolate_nans(x, method='nearest'):
-    if x.notnull().sum() > 1:
+    if x.notnull().sum() > 1 and method != "ignore":
         return x.interpolate(method=method).ffill().bfill()
-    else:
-        return x.ffill().bfill()
+    return x.ffill().bfill()


### PR DESCRIPTION
## Aim's to fix: https://github.com/m-bain/whisperX/issues/1368

--------------------------
Copying that description here:

~When using the latest version of Pandas (3.0.0)~, the interpolation method "ignore" raises a value error. 
**EDIT**: it is independent of the Pandas version (tested it with `2.1`, `2.2`, `2.3`, and `3.0`) 

<img width="1345" height="1068" alt="Image" src="https://github.com/user-attachments/assets/acd57b4a-189f-445c-a13c-5ae1c436f068" />

For what I see, there is nowhere in the WhisperX code where the "ignore" method is treated as an exception**, but [it's not in the Pandas method](https://pandas.pydata.org/pandas-docs/version/2.3/reference/api/pandas.DataFrame.interpolate.html). Instead, it seems to be passed directly to Pandas: https://github.com/m-bain/whisperX/blob/064f7379981d744ae14ceedf92c3d1e956db18a9/whisperx/utils.py#L470-L474 

** Actually, checking the entire codebase, it only appears once, in [line 34](https://github.com/m-bain/whisperX/blob/636f2988f82bcb3ad2450c4f85865a8d435a0b7c/whisperx/__main__.py#L34) of `__main__.py`

```python
    parser.add_argument("--interpolate_method", default="nearest", choices=["nearest", "linear", "ignore"], help="For word .srt, method to assign timestamps to non-aligned words, or merge them into neighbouring.")
```****