### PR TITLE
fix: remove dead model_bytes read that leaked file handle

### DIFF
--- a/whisperx/vads/pyannote.py
+++ b/whisperx/vads/pyannote.py
@@ -38,8 +38,6 @@ def load_vad_model(device, vad_onset=0.500, vad_offset=0.363, token=None, model_
     if os.path.exists(model_fp) and not os.path.isfile(model_fp):
         raise RuntimeError(f"{model_fp} exists and is not a regular file")
 
-    model_bytes = open(model_fp, "rb").read()
-
     vad_model = Model.from_pretrained(model_fp, token=token)
     hyperparameters = {"onset": vad_onset,
                     "offset": vad_offset,


### PR DESCRIPTION
The open().read() call was left behind when the SHA-256 checksum validation was removed in 86e2b3e. The resulting model_bytes variable was never used, and the file descriptor was never closed.

Closes #1376