### PR TITLE
Add token alias for Whisper model loading

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -327,6 +327,7 @@ def load_model(
     download_root: Optional[str] = None,
     local_files_only=False,
     threads=4,
+    token: Optional[Union[str, bool]] = None,
     use_auth_token: Optional[Union[str, bool]] = None,
 ) -> FasterWhisperPipeline:
     """Load a Whisper model for inference.
@@ -343,9 +344,16 @@ def load_model(
         download_root - The root directory to download the model to.
         local_files_only - If `True`, avoid downloading the file and return the path to the local cached file if it exists.
         threads - The number of cpu threads to use per worker, e.g. will be multiplied by num workers.
+        token - Hugging Face authentication token. Preferred alias.
+        use_auth_token - Legacy Hugging Face authentication token alias kept for backward compatibility.
     Returns:
         A Whisper pipeline.
     """
+
+    if token is not None and use_auth_token is not None and token != use_auth_token:
+        raise ValueError("Received conflicting values for 'token' and 'use_auth_token'")
+
+    token = token if token is not None else use_auth_token
 
     if compute_type == "default":
         compute_type = "float16" if device == "cuda" else "float32"
@@ -361,7 +369,7 @@ def load_model(
                          download_root=download_root,
                          local_files_only=local_files_only,
                          cpu_threads=threads,
-                         use_auth_token=use_auth_token)
+                         use_auth_token=token)
     if language is not None:
         tokenizer = Tokenizer(model.hf_tokenizer, model.model.is_multilingual, task=task, language=language)
     else:

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -141,7 +141,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
         task=task,
         local_files_only=model_cache_only,
         threads=faster_whisper_threads,
-        use_auth_token=hf_token,
+        token=hf_token,
     )
 
     for audio_path in args.pop("audio"):


### PR DESCRIPTION
## Summary

Adds a `token` alias to `whisperx.asr.load_model()` while preserving the existing `use_auth_token` argument for backward compatibility.

## Why

WhisperX has already migrated its pyannote-facing code to `token`, but the ASR model-loading surface still exposed `use_auth_token`.

The remaining internal use still needs to be forwarded to `faster-whisper`, whose current `WhisperModel` API expects `use_auth_token`.

This change updates the WhisperX API surface to accept `token` consistently without breaking the downstream faster-whisper call.

## Changes

- add `token` as the preferred alias in `whisperx.asr.load_model()`
- keep `use_auth_token` as a legacy alias for backward compatibility
- raise a `ValueError` if both are passed with conflicting values
- update `whisperx/transcribe.py` to pass `token=hf_token`

## Validation

- `python3 -m py_compile whisperx/asr.py whisperx/transcribe.py`

Fixes #1406
