### PR TITLE
Add Python 3.14 support (bump requires-python + torch family caps)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "whisperx"
 version = "3.8.5"
 description = "Time-Accurate Automatic Speech Recognition using Whisper."
 readme = "README.md"
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.10, <3.16"
 license = { text = "BSD-2-Clause" }
 
 dependencies = [
@@ -17,9 +17,9 @@ dependencies = [
     "pandas>=2.2.3",
     "pyannote-audio>=4.0.0",
     "huggingface-hub<1.0.0",
-    "torch~=2.8.0",
-    "torchaudio~=2.8.0",
-    "torchvision~=0.23.0",
+    "torch>=2.8.0,<2.13",
+    "torchaudio>=2.8.0,<2.13",
+    "torchvision>=0.23.0,<0.28",
     "torchcodec>=0.6.0,<0.8.0; (sys_platform == 'linux' and platform_machine == 'x86_64') or sys_platform == 'darwin' or sys_platform == 'win32'",
     "transformers>=4.48.0",
     "triton>=3.3.0; sys_platform == 'linux' and platform_machine == 'x86_64'" # only install triton on x86_64 Linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "torch>=2.8.0,<2.13",
     "torchaudio>=2.8.0,<2.13",
     "torchvision>=0.23.0,<0.28",
-    "torchcodec>=0.6.0,<0.8.0; (sys_platform == 'linux' and platform_machine == 'x86_64') or sys_platform == 'darwin' or sys_platform == 'win32'",
+    "torchcodec>=0.6.0,<0.10; (sys_platform == 'linux' and platform_machine == 'x86_64') or sys_platform == 'darwin' or sys_platform == 'win32'",
     "transformers>=4.48.0",
     "triton>=3.3.0; sys_platform == 'linux' and platform_machine == 'x86_64'" # only install triton on x86_64 Linux
 ]
@@ -45,7 +45,7 @@ include = ["whisperx*"]
 # torchcodec (transitive dep of pyannote-audio >=4) has no wheels for Linux aarch64
 [tool.uv]
 override-dependencies = [
-    "torchcodec>=0.6.0,<0.8.0; (sys_platform == 'linux' and platform_machine == 'x86_64') or sys_platform == 'darwin' or sys_platform == 'win32'",
+    "torchcodec>=0.6.0,<0.10; (sys_platform == 'linux' and platform_machine == 'x86_64') or sys_platform == 'darwin' or sys_platform == 'win32'",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
## Summary

Two pyproject.toml changes that together let `pip install whisperx` resolve on Python 3.14:

1. Bump `requires-python` upper bound from `<3.14` to `<3.16`.
2. Widen the torch family caps so the cp314 wheels can be selected:
   - `torch ~=2.8.0` → `>=2.8.0,<2.13` (cp314 macOS arm64 starts at 2.9.0)
   - `torchaudio ~=2.8.0` → `>=2.8.0,<2.13` (cp314 starts at 2.9.0)
   - `torchvision ~=0.23.0` → `>=0.23.0,<0.28` (cp314 starts at 0.24.0)
   - `torchcodec >=0.6.0,<0.8.0` → `>=0.6.0,<0.10` (cp314 starts at 0.9.0)

## Why these bounds

Floors are preserved (2.8.0 / 0.23.0 / 0.6.0) so existing users on Python 3.10–3.13 with torch 2.8.x are unaffected. The new caps sit just above today's latest publishes, matching the project's existing pin style (caps kept, not removed).

The torch family widening is necessary alongside the `requires-python` bump: cp314 macOS arm64 wheels didn't exist for these packages until torch 2.9.0 / torchaudio 2.9.0 / torchvision 0.24.0 / torchcodec 0.9.0, so the current `~=2.8.0` pins exclude every cp314 wheel.

## Tested

On macOS arm64, Python 3.14.5, installed via \`pip install git+https://github.com/dbacks2196/whisperX.git@bump-python-upper-bound\`:

- Resolver cleanly selects torch 2.12.0, torchaudio 2.11.0, torchvision 0.27.0, torchcodec 0.9.1, transformers 5.9.0, pyannote-audio 4.0.4, faster-whisper 1.2.1.
- \`import whisperx\` succeeds.
- End-to-end ASR + word-level wav2vec2 alignment + pyannote diarization pipeline runs against multi-minute WAV inputs on MPS.
- Downstream scoring pipeline produces functionally identical top-N rankings vs. a Python 3.12 / torch 2.8 baseline (composite scores within ±0.04, transcripts identical modulo whisper's run-to-run punctuation noise).

## Notes

- \`huggingface-hub<1.0.0\` is intentionally left alone — separate concern, out of scope here.
- Happy to adjust the cap style if you'd prefer something different: tighter (e.g. \`~=2.12.0\` matching the exact-minor convention), looser (caps removed entirely), or split into two PRs (the \`requires-python\` bump separated from the dep bumps).