### PR TITLE
fix: support pathlib.Path and os.PathLike objects (#1281)

### DIFF
--- a/tests/test_pathlib.py
+++ b/tests/test_pathlib.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import unittest
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import torch
+
+from whisperx.audio import load_audio, log_mel_spectrogram
+from whisperx.utils import WriteTXT
+
+
+class TestPathlibSupport(unittest.TestCase):
+
+    @patch('subprocess.run')
+    def test_load_audio_pathlib(self, mock_run):
+        mock_run.return_value.stdout = np.zeros(16000, dtype=np.int16).tobytes()
+        
+        # This should accept a Path object and convert it to string path
+        audio_path = Path("test_audio.wav")
+        load_audio(audio_path)
+        
+        # Verify that subprocess.run was called with string path
+        called_args = mock_run.call_args[0][0]
+        self.assertIn("test_audio.wav", called_args)
+
+    @patch('whisperx.audio.load_audio')
+    def test_log_mel_spectrogram_pathlib(self, mock_load_audio):
+        mock_load_audio.return_value = np.zeros(16000, dtype=np.float32)
+        
+        # This should accept a Path object and invoke load_audio
+        audio_path = Path("test_audio.wav")
+        log_mel_spectrogram(audio_path, n_mels=80)
+        
+        mock_load_audio.assert_called_once_with(audio_path)
+
+    def test_result_writer_pathlib(self):
+        writer = WriteTXT(Path("/tmp/output"))
+        self.assertEqual(writer.output_dir, str(Path("/tmp/output")))

--- a/whisperx/SubtitlesProcessor.py
+++ b/whisperx/SubtitlesProcessor.py
@@ -1,4 +1,6 @@
 import math
+import os
+from typing import Union
 from whisperx.conjunctions import get_conjunctions, get_comma
 
 def normal_round(n):
@@ -202,8 +204,8 @@ class SubtitlesProcessor:
     
 
 
-    def save(self, filename="subtitles.srt", advanced_splitting=True):
-        
+    def save(self, filename: Union[str, os.PathLike] = "subtitles.srt", advanced_splitting=True):
+        filename = os.fspath(filename)
         subtitles = self.process_segments(advanced_splitting)
 
         def write_subtitle(file, idx, start_time, end_time, text):

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -2,6 +2,7 @@
 Forced Alignment with Whisper
 C. Max Bain
 """
+import os
 from dataclasses import dataclass
 from typing import Iterable, Optional, Union, List
 
@@ -118,7 +119,7 @@ def align(
     transcript: Iterable[SingleSegment],
     model: torch.nn.Module,
     align_model_metadata: dict,
-    audio: Union[str, np.ndarray, torch.Tensor],
+    audio: Union[str, os.PathLike, np.ndarray, torch.Tensor],
     device: str,
     interpolate_method: str = "nearest",
     return_char_alignments: bool = False,
@@ -131,7 +132,7 @@ def align(
     """
 
     if not torch.is_tensor(audio):
-        if isinstance(audio, str):
+        if isinstance(audio, (str, os.PathLike)):
             audio = load_audio(audio)
         audio = torch.from_numpy(audio)
     if len(audio.shape) == 1:

--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -196,7 +196,7 @@ class FasterWhisperPipeline(Pipeline):
 
     def transcribe(
         self,
-        audio: Union[str, np.ndarray],
+        audio: Union[str, os.PathLike, np.ndarray],
         batch_size: Optional[int] = None,
         num_workers=0,
         language: Optional[str] = None,
@@ -207,7 +207,7 @@ class FasterWhisperPipeline(Pipeline):
         verbose=False,
         progress_callback: ProgressCallback = None,
     ) -> TranscriptionResult:
-        if isinstance(audio, str):
+        if isinstance(audio, (str, os.PathLike)):
             audio = load_audio(audio)
 
         def data(audio, segments):

--- a/whisperx/audio.py
+++ b/whisperx/audio.py
@@ -22,13 +22,13 @@ FRAMES_PER_SECOND = exact_div(SAMPLE_RATE, HOP_LENGTH)  # 10ms per audio frame
 TOKENS_PER_SECOND = exact_div(SAMPLE_RATE, N_SAMPLES_PER_TOKEN)  # 20ms per audio token
 
 
-def load_audio(file: str, sr: int = SAMPLE_RATE) -> np.ndarray:
+def load_audio(file: Union[str, os.PathLike], sr: int = SAMPLE_RATE) -> np.ndarray:
     """
     Open an audio file and read as mono waveform, resampling as necessary
 
     Parameters
     ----------
-    file: str
+    file: Union[str, os.PathLike]
         The audio file to open
 
     sr: int
@@ -38,6 +38,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE) -> np.ndarray:
     -------
     A NumPy array containing the audio waveform, in float32 dtype.
     """
+    file = os.fspath(file)
     try:
         # Launches a subprocess to decode audio while down-mixing and resampling as necessary.
         # Requires the ffmpeg CLI to be installed.
@@ -110,7 +111,7 @@ def mel_filters(device, n_mels: int) -> torch.Tensor:
 
 
 def log_mel_spectrogram(
-    audio: Union[str, np.ndarray, torch.Tensor],
+    audio: Union[str, os.PathLike, np.ndarray, torch.Tensor],
     n_mels: int,
     padding: int = 0,
     device: Optional[Union[str, torch.device]] = None,
@@ -120,7 +121,7 @@ def log_mel_spectrogram(
 
     Parameters
     ----------
-    audio: Union[str, np.ndarray, torch.Tensor], shape = (*)
+    audio: Union[str, os.PathLike, np.ndarray, torch.Tensor], shape = (*)
         The path to audio or either a NumPy array or Tensor containing the audio waveform in 16 kHz
 
     n_mels: int
@@ -138,7 +139,7 @@ def log_mel_spectrogram(
         A Tensor that contains the Mel spectrogram
     """
     if not torch.is_tensor(audio):
-        if isinstance(audio, str):
+        if isinstance(audio, (str, os.PathLike)):
             audio = load_audio(audio)
         audio = torch.from_numpy(audio)
 

--- a/whisperx/diarize.py
+++ b/whisperx/diarize.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import pandas as pd
 from pyannote.audio import Pipeline
@@ -104,7 +105,7 @@ class DiarizationPipeline:
 
     def __call__(
         self,
-        audio: Union[str, np.ndarray],
+        audio: Union[str, os.PathLike, np.ndarray],
         num_speakers: Optional[int] = None,
         min_speakers: Optional[int] = None,
         max_speakers: Optional[int] = None,
@@ -128,7 +129,7 @@ class DiarizationPipeline:
             Otherwise:
                 Just the diarization dataframe
         """
-        if isinstance(audio, str):
+        if isinstance(audio, (str, os.PathLike)):
             audio = load_audio(audio)
         audio_data = {
             'waveform': torch.from_numpy(audio[None, :]),

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 import zlib
-from typing import Callable, Optional, TextIO
+from typing import Callable, Optional, TextIO, Union
 
 LANGUAGES = {
     "en": "english",
@@ -215,10 +215,11 @@ def format_timestamp(
 class ResultWriter:
     extension: str
 
-    def __init__(self, output_dir: str):
-        self.output_dir = output_dir
+    def __init__(self, output_dir: Union[str, os.PathLike]):
+        self.output_dir = os.fspath(output_dir)
 
-    def __call__(self, result: dict, audio_path: str, options: dict):
+    def __call__(self, result: dict, audio_path: Union[str, os.PathLike], options: dict):
+        audio_path = os.fspath(audio_path)
         audio_basename = os.path.basename(audio_path)
         audio_basename = os.path.splitext(audio_basename)[0]
         output_path = os.path.join(


### PR DESCRIPTION
Closes #1281

## Problem
Currently, various public functions and classes in whisperX (such as load_audio, transcribe, align, diarize, and ResultWriter subclasses) expect file paths to be passed strictly as string objects. When users pass pathlib.Path objects programmatically, it results in errors like TypeError or AttributeError due to type checks (e.g. isinstance(audio, str)) or subprocess errors.

## Fix
1. Accept Union[str, os.PathLike] as parameters where file paths are received.
2. Safe-cast PathLike parameters using os.fspath() to ensure they are compatible with standard operations and subprocess calls.
3. Update isinstance(audio, str) type checks to isinstance(audio, (str, os.PathLike)) to correctly load audio from path objects.

## Tests
Added 'tests/test_pathlib.py' containing unit tests for load_audio, log_mel_spectrogram, and ResultWriter to guarantee pathlib.Path is correctly accepted and resolved without raising errors.