### PR TITLE
chore(deps): update exclude-newer settings

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          version: "0.5.14"
+          version: "0.11.6
           python-version: "3.10"
           enable-cache: false
 

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          version: "0.5.14"
+          version: "0.11.6"
           python-version: ${{ matrix.python-version }}
 
       - name: Check if lockfile is up to date

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          version: "0.5.14"
+          version: "0.11.6"
           python-version: ${{ matrix.python-version }}
 
       - name: Install the project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,13 @@ include = ["whisperx*"]
 
 # torchcodec (transitive dep of pyannote-audio >=4) has no wheels for Linux aarch64
 [tool.uv]
+exclude-newer = "1 week"
 override-dependencies = [
     "torchcodec>=0.6.0,<0.8.0; (sys_platform == 'linux' and platform_machine == 'x86_64') or sys_platform == 'darwin' or sys_platform == 'win32'",
 ]
+
+[tool.uv.pip]
+exclude-newer = "1 week"
 
 [tool.uv.sources]
 torch = [

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,10 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform != 'darwin'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
 [manifest]
 overrides = [{ name = "torchcodec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=0.6.0,<0.8.0" }]
 


### PR DESCRIPTION
Limit packages to those that were uploaded more than 7 days ago (rolling window), to minimize the risk of supply chain attacks.