### PR TITLE
fix: skip initial silence to improve language detection accuracy

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -216,14 +216,26 @@ class FasterWhisperPipeline(Pipeline):
             offset=self._vad_params["vad_offset"],
         )
         if self.tokenizer is None:
-            # If VAD found speech segments, start language detection from the first spoken word
-            if len(vad_segments) > 0:
-                first_speech_start_idx = int(vad_segments[0]['start'] * SAMPLE_RATE)
-                print(f"Skipping initial silence. Detecting language starting at {vad_segments[0]['start']:.2f}s")
-                language = language or self.detect_language(audio[first_speech_start_idx:])
-            else:
-                # Fallback if no speech was detected at all by VAD
-                language = language or self.detect_language(audio)
+            if language is None:
+                # If VAD found speech segments, start language detection from the first spoken word
+                if len(vad_segments) > 0:
+                    first_speech_start_idx = int(vad_segments[0]['start'] * SAMPLE_RATE)
+                    sliced_audio = audio[first_speech_start_idx:]
+                    
+                    # Calculate the exact minimum samples needed for a 25ms spectrogram window
+                    min_required_samples = int(0.025 * SAMPLE_RATE) 
+                    
+                    if len(sliced_audio) >= min_required_samples:
+                        print(f"Skipping initial silence. Detecting language starting at {vad_segments[0]['start']:.2f}s")
+                        language = self.detect_language(sliced_audio)
+                    else:
+                        # Added the lengths into the print statement for better debugging logs
+                        print(f"Warning: VAD slice is too short or out of bounds (Got {len(sliced_audio)} samples, need at least {min_required_samples}). Falling back to full audio.")
+                        language = self.detect_language(audio)
+                else:
+                    # Fallback if no speech was detected at all by VAD
+                    language = self.detect_language(audio)
+
             task = task or "transcribe"
             self.tokenizer = Tokenizer(
                 self.model.hf_tokenizer,

--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -222,8 +222,9 @@ class FasterWhisperPipeline(Pipeline):
                     first_speech_start_idx = int(vad_segments[0]['start'] * SAMPLE_RATE)
                     sliced_audio = audio[first_speech_start_idx:]
                     
-                    # Calculate the exact minimum samples needed for a 25ms spectrogram window
-                    min_required_samples = int(0.025 * SAMPLE_RATE) 
+                    # Require at least 0.5 seconds of audio for reliable language detection
+                    min_required_seconds = 0.5
+                    min_required_samples = int(min_required_seconds * SAMPLE_RATE)
                     
                     if len(sliced_audio) >= min_required_samples:
                         print(f"Skipping initial silence. Detecting language starting at {vad_segments[0]['start']:.2f}s")

--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -216,7 +216,14 @@ class FasterWhisperPipeline(Pipeline):
             offset=self._vad_params["vad_offset"],
         )
         if self.tokenizer is None:
-            language = language or self.detect_language(audio)
+            # If VAD found speech segments, start language detection from the first spoken word
+            if len(vad_segments) > 0:
+                first_speech_start_idx = int(vad_segments[0]['start'] * SAMPLE_RATE)
+                print(f"Skipping initial silence. Detecting language starting at {vad_segments[0]['start']:.2f}s")
+                language = language or self.detect_language(audio[first_speech_start_idx:])
+            else:
+                # Fallback if no speech was detected at all by VAD
+                language = language or self.detect_language(audio)
             task = task or "transcribe"
             self.tokenizer = Tokenizer(
                 self.model.hf_tokenizer,


### PR DESCRIPTION
Previously, `detect_language` always analyzed the first 30 seconds of the raw audio file. If a file started with a long period of silence, the language detector would evaluate background noise, resulting in inaccurate language guesses.

This change leverages the already-computed `vad_segments` to find the timestamp of the first actual spoken word. By slicing the audio array at `first_speech_start_idx`, the language detector now correctly analyzes the first 30 seconds of actual speech. A fallback remains in place for files where no speech is detected.