### PR TITLE
Gracefully skip alignment for languages with no align model (#298)

### DIFF
--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -183,9 +183,21 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
                     logger.info(
                         f"New language found ({result['language']})! Previous was ({align_metadata['language']}), loading new alignment model for new language..."
                     )
-                    align_model, align_metadata = load_align_model(
-                        result["language"], device, model_dir=model_dir, model_cache_only=model_cache_only
-                    )
+                    try:
+                        align_model, align_metadata = load_align_model(
+                            result["language"], device, model_dir=model_dir, model_cache_only=model_cache_only
+                        )
+                    except ValueError as e:
+                        # No alignment model for this language — often a mis-detected
+                        # "phantom" language in a single chunk. Warn and keep the unaligned
+                        # (segment-level) transcription for this result instead of crashing
+                        # the whole run. See #298.
+                        logger.warning(
+                            f"Skipping alignment for language '{result.get('language')}': {e} "
+                            f"Keeping unaligned segment-level transcription for this audio."
+                        )
+                        results.append((result, audio_path))
+                        continue
                 logger.info("Performing alignment...")
                 result: AlignedTranscriptionResult = align(
                     result["segments"],


### PR DESCRIPTION
## Summary

Fixes #298. A single chunk detected as a "phantom" language with **no alignment
model** currently raises `ValueError` from `load_align_model` mid-run and **crashes
the entire transcription job** — losing all output, including the chunks that
transcribed fine.

This makes that failure non-fatal: when a result's detected language has no align
model, log a warning, keep that result's **unaligned segment-level** transcription,
and continue. The run completes and produces output. This is the behavior requested
in the issue.

## The fix

`whisperx/transcribe.py` — in `transcribe_task`'s align loop, the per-result
"New language found" reload is wrapped in `try/except ValueError`:

```python
try:
    align_model, align_metadata = load_align_model(
        result["language"], device, model_dir=model_dir, model_cache_only=model_cache_only
    )
except ValueError as e:
    # No alignment model for this language — often a mis-detected "phantom"
    # language in a single chunk. Warn and keep the unaligned (segment-level)
    # transcription for this result instead of crashing the whole run. See #298.
    logger.warning(
        f"Skipping alignment for language '{result.get('language')}': {e} "
        f"Keeping unaligned segment-level transcription for this audio."
    )
    results.append((result, audio_path))
    continue
```

No behavior change for supported languages — the happy path is untouched.

## Validation (on real audio)

Tested end-to-end with CPU/int8 inference against short gTTS-generated clips, plus a
before/after on the **same clip** against released `whisperx==3.8.6`:

| Case | Result |
|------|--------|
| **English clip** (supported lang) | exit 0 · `en` detected · alignment ran · **word-level** SRT · no skip warning *(no regression)* |
| **Thai clip** (no align model, auto-detect) | exit 0 · `New language found (th)!` → `WARNING - Skipping alignment for language 'th'` → segment-level SRT written |
| **Same Thai clip, released 3.8.6** | **exit 1**, `ValueError: No default align-model for language: th`, **no output** |
| **Same Thai clip, this patch** | **exit 0**, output written |

Identical entry point, opposite outcome: both builds hit the per-result
`load_align_model(th)` after detection; released crashes, patched warns-and-continues.

## Notes

This is a minimal, fix-only change. The align loop isn't cleanly unit-testable
without a small refactor (extracting the reload into a helper); happy to follow up
with that + a regression test if maintainers would like it.

---

*Disclosure: this fix was drafted with AI assistance (Claude) and reviewed,
tested, and submitted by me. The commit carries a `Co-Authored-By` trailer.*
