### PR TITLE
feat: add --highlight_color and --highlight_score_colors options for word-level highlight (#415)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ You can also customize the highlight color (useful for different subtitle render
     whisperx path/to/audio.wav --highlight_words True --highlight_color red
     whisperx path/to/audio.wav --highlight_words True --highlight_color "#00ff00"
 
+Or color words by their alignment confidence score:
+
+    whisperx path/to/audio.wav --highlight_words True --highlight_score_colors "0.3:red,0.7:yellow,1.0:green"
+
 To run on CPU instead of GPU (and for running on Mac OS X):
 
     whisperx path/to/audio.wav --compute_type int8 --device cpu

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ To label the transcript with speaker ID's (set number of speakers if known e.g. 
 
     whisperx path/to/audio.wav --model large-v2 --diarize --highlight_words True
 
+You can also customize the highlight color (useful for different subtitle rendering engines):
+
+    whisperx path/to/audio.wav --highlight_words True --highlight_color red
+    whisperx path/to/audio.wav --highlight_words True --highlight_color "#00ff00"
+
 To run on CPU instead of GPU (and for running on Mac OS X):
 
     whisperx path/to/audio.wav --compute_type int8 --device cpu

--- a/tests/test_highlight_color.py
+++ b/tests/test_highlight_color.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from whisperx.utils import _apply_highlight, WriteVTT, WriteSRT
+from whisperx.utils import (
+    _apply_highlight,
+    _parse_score_color_map,
+    _select_score_color,
+    WriteVTT,
+    WriteSRT,
+)
 
 
 class TestApplyHighlight:
@@ -43,6 +49,63 @@ class TestApplyHighlight:
                 assert result.count("<u>") == result.count("</u>"), (
                     f"Unbalanced u tags in: {result!r}"
                 )
+
+    def test_score_color_map_overrides_fixed_color(self):
+        score_color_map = [(0.5, "red"), (0.8, "green")]
+        result = _apply_highlight("hello", "blue", is_current=True, score_color_map=score_color_map, score=0.9)
+        assert '<font color="green">' in result
+
+    def test_score_color_map_falls_back_when_score_missing(self):
+        score_color_map = [(0.5, "red"), (0.8, "green")]
+        result = _apply_highlight("hello", "blue", is_current=True, score_color_map=score_color_map, score=None)
+        assert '<font color="blue">' in result
+
+    def test_score_color_map_selects_color_by_threshold(self):
+        score_color_map = [(0.3, "red"), (0.7, "yellow"), (1.0, "green")]
+        low = _apply_highlight("x", None, is_current=True, score_color_map=score_color_map, score=0.2)
+        mid = _apply_highlight("x", None, is_current=True, score_color_map=score_color_map, score=0.5)
+        high = _apply_highlight("x", None, is_current=True, score_color_map=score_color_map, score=0.9)
+        assert '<font color="red">' in low
+        assert '<font color="yellow">' in mid
+        assert '<font color="green">' in high
+
+
+class TestScoreColorMapHelpers:
+    """Unit tests for score color map parsing and selection."""
+
+    def test_parse_score_color_map(self):
+        assert _parse_score_color_map("0:red,0.5:yellow,0.8:green") == [
+            (0.0, "red"),
+            (0.5, "yellow"),
+            (0.8, "green"),
+        ]
+
+    def test_parse_score_color_map_sorts_by_threshold(self):
+        assert _parse_score_color_map("0.8:green,0:red,0.5:yellow") == [
+            (0.0, "red"),
+            (0.5, "yellow"),
+            (0.8, "green"),
+        ]
+
+    def test_parse_score_color_map_empty(self):
+        assert _parse_score_color_map("") == []
+
+    def test_parse_score_color_map_invalid_format(self):
+        with pytest.raises(ValueError):
+            _parse_score_color_map("0.5red")
+
+    def test_select_score_color_below_threshold(self):
+        score_color_map = [(0.5, "red"), (0.8, "yellow"), (1.0, "green")]
+        assert _select_score_color(score_color_map, 0.3) == "red"
+
+    def test_select_score_color_at_boundary(self):
+        score_color_map = [(0.5, "red"), (0.8, "yellow"), (1.0, "green")]
+        assert _select_score_color(score_color_map, 0.5) == "yellow"
+        assert _select_score_color(score_color_map, 0.8) == "green"
+
+    def test_select_score_color_above_all(self):
+        score_color_map = [(0.5, "red"), (0.8, "yellow"), (1.0, "green")]
+        assert _select_score_color(score_color_map, 0.95) == "green"
 
 
 def _make_minimal_result():
@@ -166,3 +229,63 @@ class TestSubtitlesWriterHighlight:
             assert text.count("<u>") == text.count("</u>"), (
                 f"Unbalanced tags in: {text!r}"
             )
+
+    def test_score_colors_rendered_based_on_score(self):
+        """Words are colored according to their alignment score."""
+        result = {
+            "language": "en",
+            "segments": [
+                {
+                    "start": 0.0,
+                    "end": 3.0,
+                    "text": "hello world test",
+                    "words": [
+                        {"word": "hello", "start": 0.0, "end": 0.5, "score": 0.2},
+                        {"word": "world", "start": 0.6, "end": 1.0, "score": 0.6},
+                        {"word": "test", "start": 1.1, "end": 1.5, "score": 0.9},
+                    ],
+                }
+            ],
+        }
+        opts = {
+            "highlight_words": True,
+            "max_line_width": None,
+            "max_line_count": None,
+            "highlight_color": "gray",
+            "highlight_score_colors": "0.3:red,0.7:yellow,1.0:green",
+        }
+        vtt = WriteVTT(output_dir=".")
+        lines = list(vtt.iterate_result(result, opts))
+        texts = "\n".join([ln[2] for ln in lines])
+        assert '<font color="red">hello</font>' in texts, f"got: {texts}"
+        assert '<font color="yellow">world</font>' in texts, f"got: {texts}"
+        assert '<font color="green">test</font>' in texts, f"got: {texts}"
+
+    def test_score_colors_missing_score_falls_back_to_highlight_color(self):
+        """If a word lacks a score, it should use the fixed --highlight_color."""
+        result = {
+            "language": "en",
+            "segments": [
+                {
+                    "start": 0.0,
+                    "end": 2.0,
+                    "text": "hello world",
+                    "words": [
+                        {"word": "hello", "start": 0.0, "end": 0.5, "score": 0.2},
+                        {"word": "world", "start": 0.6, "end": 1.0},
+                    ],
+                }
+            ],
+        }
+        opts = {
+            "highlight_words": True,
+            "max_line_width": None,
+            "max_line_count": None,
+            "highlight_color": "gray",
+            "highlight_score_colors": "0.3:red,0.7:yellow,1.0:green",
+        }
+        vtt = WriteVTT(output_dir=".")
+        lines = list(vtt.iterate_result(result, opts))
+        texts = "\n".join([ln[2] for ln in lines])
+        assert '<font color="red">hello</font>' in texts, f"got: {texts}"
+        assert '<font color="gray">world</font>' in texts, f"got: {texts}"

--- a/tests/test_highlight_color.py
+++ b/tests/test_highlight_color.py
@@ -1,0 +1,168 @@
+"""Unit tests for the --highlight_color feature in subtitle output."""
+
+import pytest
+
+from whisperx.utils import _apply_highlight, WriteVTT, WriteSRT
+
+
+class TestApplyHighlight:
+    """Unit tests for _apply_highlight."""
+
+    def test_not_current_returns_word_unchanged(self):
+        assert _apply_highlight("hello", None, is_current=False) == "hello"
+        assert _apply_highlight("world", "red", is_current=False) == "world"
+        assert _apply_highlight(" foo", None, is_current=False) == " foo"
+
+    def test_current_no_color_adds_underline(self):
+        assert _apply_highlight("hello", None, is_current=True) == "<u>hello</u>"
+
+    def test_current_with_color_adds_font_tag(self):
+        assert _apply_highlight("hello", "red", is_current=True) == '<font color="red">hello</font>'
+        assert _apply_highlight("hello", "#00ff00", is_current=True) == '<font color="#00ff00">hello</font>'
+
+    def test_current_preserves_leading_whitespace(self):
+        assert _apply_highlight("\nhello", None, is_current=True) == "\n<u>hello</u>"
+        assert _apply_highlight("\nworld", "red", is_current=True) == '\n<font color="red">world</font>'
+
+    def test_tags_balanced_for_every_input(self):
+        """Every call with is_current=True produces balanced open/close tags."""
+        cases = [
+            ("word", None),
+            ("word", "red"),
+            ("word", "#ff0000"),
+            ("\nword", None),
+            (" word", "green"),
+        ]
+        for word, color in cases:
+            result = _apply_highlight(word, color, is_current=True)
+            if color:
+                assert result.count(f'<font color="{color}">') == result.count("</font>"), (
+                    f"Unbalanced font tags in: {result!r}"
+                )
+            else:
+                assert result.count("<u>") == result.count("</u>"), (
+                    f"Unbalanced u tags in: {result!r}"
+                )
+
+
+def _make_minimal_result():
+    """Return a minimal transcription result with word-level timestamps."""
+    return {
+        "language": "en",
+        "segments": [
+            {
+                "start": 0.0,
+                "end": 3.0,
+                "text": "hello world",
+                "words": [
+                    {"word": "hello", "start": 0.0, "end": 0.5},
+                    {"word": "world", "start": 0.6, "end": 1.0},
+                ],
+            }
+        ],
+    }
+
+
+class TestSubtitlesWriterHighlight:
+    """Integration tests for highlight_words + highlight_color in subtitle output."""
+
+    def test_no_highlight_produces_plain_text(self):
+        result = _make_minimal_result()
+        opts = {
+            "highlight_words": False,
+            "max_line_width": None,
+            "max_line_count": None,
+            "highlight_color": None,
+        }
+        vtt = WriteVTT(output_dir=".")
+        lines = list(vtt.iterate_result(result, opts))
+        texts = [ln[2] for ln in lines]
+        assert not any("<u>" in t for t in texts)
+        assert not any("<font" in t for t in texts)
+
+    def test_highlight_default_underline(self):
+        result = _make_minimal_result()
+        opts = {
+            "highlight_words": True,
+            "max_line_width": None,
+            "max_line_count": None,
+            "highlight_color": None,
+        }
+        vtt = WriteVTT(output_dir=".")
+        lines = list(vtt.iterate_result(result, opts))
+        texts = [ln[2] for ln in lines]
+        assert any("<u>" in t for t in texts), f"Expected <u>, got: {texts}"
+        assert not any("<font" in t for t in texts)
+
+    def test_highlight_with_color(self):
+        result = _make_minimal_result()
+        opts = {
+            "highlight_words": True,
+            "max_line_width": None,
+            "max_line_count": None,
+            "highlight_color": "red",
+        }
+        vtt = WriteVTT(output_dir=".")
+        lines = list(vtt.iterate_result(result, opts))
+        texts = [ln[2] for ln in lines]
+        assert any('<font color="red">' in t for t in texts), f"Expected font, got: {texts}"
+        assert any("</font>" in t for t in texts)
+        assert not any("<u>" in t for t in texts), "No <u> expected with custom color"
+
+    def test_highlight_color_hex(self):
+        result = _make_minimal_result()
+        opts = {
+            "highlight_words": True,
+            "max_line_width": None,
+            "max_line_count": None,
+            "highlight_color": "#00ff00",
+        }
+        vtt = WriteVTT(output_dir=".")
+        lines = list(vtt.iterate_result(result, opts))
+        texts = [ln[2] for ln in lines]
+        assert any('<font color="#00ff00">' in t for t in texts)
+
+    def test_srt_highlight_with_color(self):
+        result = _make_minimal_result()
+        opts = {
+            "highlight_words": True,
+            "max_line_width": None,
+            "max_line_count": None,
+            "highlight_color": "yellow",
+        }
+        srt = WriteSRT(output_dir=".")
+        lines = list(srt.iterate_result(result, opts))
+        texts = [ln[2] for ln in lines]
+        assert any('<font color="yellow">' in t for t in texts)
+
+    def test_tag_balance(self):
+        """Every opening tag must have a matching closing tag in each cue."""
+        result = _make_minimal_result()
+        opts = {
+            "highlight_words": True,
+            "max_line_width": None,
+            "max_line_count": None,
+            "highlight_color": "red",
+        }
+        srt = WriteSRT(output_dir=".")
+        lines = list(srt.iterate_result(result, opts))
+        for _, _, text in lines:
+            assert text.count('<font color="red">') == text.count("</font>"), (
+                f"Unbalanced tags in: {text!r}"
+            )
+
+    def test_tag_balance_default_underline(self):
+        """Tag balance also holds for default underline mode."""
+        result = _make_minimal_result()
+        opts = {
+            "highlight_words": True,
+            "max_line_width": None,
+            "max_line_count": None,
+            "highlight_color": None,
+        }
+        srt = WriteSRT(output_dir=".")
+        lines = list(srt.iterate_result(result, opts))
+        for _, _, text in lines:
+            assert text.count("<u>") == text.count("</u>"), (
+                f"Unbalanced tags in: {text!r}"
+            )

--- a/whisperx/__main__.py
+++ b/whisperx/__main__.py
@@ -71,6 +71,7 @@ def cli():
     parser.add_argument("--max_line_count", type=optional_int, default=None, help="(not possible with --no_align) the maximum number of lines in a segment")
     parser.add_argument("--highlight_words", type=str2bool, default=False, help="(not possible with --no_align) underline each word as it is spoken in srt and vtt")
     parser.add_argument("--highlight_color", type=str, default=None, help="(requires --highlight_words) color for highlighted words in srt/vtt, e.g. 'red', 'green', '#00ff00'; uses default underline when not set")
+    parser.add_argument("--highlight_score_colors", type=str, default=None, help="(requires --highlight_words) map alignment scores to colors, e.g. '0:gray,0.5:yellow,0.8:green' to color words based on confidence; overrides --highlight_color")
     parser.add_argument("--segment_resolution", type=str, default="sentence", choices=["sentence", "chunk"], help="(not possible with --no_align) the maximum number of characters in a line before breaking the line")
 
     parser.add_argument("--threads", type=optional_int, default=0, help="number of threads used by torch for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS")

--- a/whisperx/__main__.py
+++ b/whisperx/__main__.py
@@ -70,6 +70,7 @@ def cli():
     parser.add_argument("--max_line_width", type=optional_int, default=None, help="(not possible with --no_align) the maximum number of characters in a line before breaking the line")
     parser.add_argument("--max_line_count", type=optional_int, default=None, help="(not possible with --no_align) the maximum number of lines in a segment")
     parser.add_argument("--highlight_words", type=str2bool, default=False, help="(not possible with --no_align) underline each word as it is spoken in srt and vtt")
+    parser.add_argument("--highlight_color", type=str, default=None, help="(requires --highlight_words) color for highlighted words in srt/vtt, e.g. 'red', 'green', '#00ff00'; uses default underline when not set")
     parser.add_argument("--segment_resolution", type=str, default="sentence", choices=["sentence", "chunk"], help="(not possible with --no_align) the maximum number of characters in a line before breaking the line")
 
     parser.add_argument("--threads", type=optional_int, default=0, help="number of threads used by torch for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS")

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -112,7 +112,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
     }
 
     writer = get_writer(output_format, output_dir)
-    word_options = ["highlight_words", "max_line_count", "max_line_width", "highlight_color"]
+    word_options = ["highlight_words", "max_line_count", "max_line_width", "highlight_color", "highlight_score_colors"]
     if no_align:
         for option in word_options:
             if args[option]:

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -112,7 +112,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
     }
 
     writer = get_writer(output_format, output_dir)
-    word_options = ["highlight_words", "max_line_count", "max_line_width"]
+    word_options = ["highlight_words", "max_line_count", "max_line_width", "highlight_color"]
     if no_align:
         for option in word_options:
             if args[option]:

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -191,6 +191,24 @@ def compression_ratio(text) -> float:
     return len(text_bytes) / len(zlib.compress(text_bytes))
 
 
+def _apply_highlight(word: str, color: Optional[str], *, is_current: bool) -> str:
+    """Surround `word` with a highlight tag when it is the current word.
+
+    Strips leading whitespace before the tag so that ``<u>hello</u>`` rather
+    than `` <u>hello</u>`` is produced.  When `color` is given uses a
+    ``<font color="...">`` tag; otherwise uses the legacy ``<u>`` underline.
+    """
+    if not is_current:
+        return word
+    match = re.match(r"^(\s*)(.*)$", word)
+    if match is None:
+        return word
+    prefix, body = match.group(1), match.group(2)
+    if color:
+        return f'{prefix}<font color="{color}">{body}</font>'
+    return f"{prefix}<u>{body}</u>"
+
+
 def format_timestamp(
     seconds: float, always_include_hours: bool = False, decimal_marker: str = "."
 ):
@@ -253,6 +271,7 @@ class SubtitlesWriter(ResultWriter):
         raw_max_line_width: Optional[int] = options["max_line_width"]
         max_line_count: Optional[int] = options["max_line_count"]
         highlight_words: bool = options["highlight_words"]
+        highlight_color: Optional[str] = options.get("highlight_color")
         max_line_width = 1000 if raw_max_line_width is None else raw_max_line_width
         preserve_segments = max_line_count is None or raw_max_line_width is None
 
@@ -342,9 +361,7 @@ class SubtitlesWriter(ResultWriter):
 
                             yield start, end, prefix + " ".join(
                                 [
-                                    re.sub(r"^(\s*)(.*)$", r"\1<u>\2</u>", word)
-                                    if j == i
-                                    else word
+                                    _apply_highlight(word, highlight_color, is_current=(j == i))
                                     for j, word in enumerate(all_words)
                                 ]
                             )

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -191,12 +191,21 @@ def compression_ratio(text) -> float:
     return len(text_bytes) / len(zlib.compress(text_bytes))
 
 
-def _apply_highlight(word: str, color: Optional[str], *, is_current: bool) -> str:
+def _apply_highlight(
+    word: str,
+    color: Optional[str],
+    *,
+    is_current: bool,
+    score_color_map: Optional[list[tuple[float, str]]] = None,
+    score: Optional[float] = None,
+) -> str:
     """Surround `word` with a highlight tag when it is the current word.
 
     Strips leading whitespace before the tag so that ``<u>hello</u>`` rather
     than `` <u>hello</u>`` is produced.  When `color` is given uses a
     ``<font color="...">`` tag; otherwise uses the legacy ``<u>`` underline.
+    If `score_color_map` is provided, the color is selected based on `score`
+    instead of using the fixed `color`.
     """
     if not is_current:
         return word
@@ -204,9 +213,48 @@ def _apply_highlight(word: str, color: Optional[str], *, is_current: bool) -> st
     if match is None:
         return word
     prefix, body = match.group(1), match.group(2)
-    if color:
-        return f'{prefix}<font color="{color}">{body}</font>'
+
+    selected_color = color
+    if score_color_map is not None and score is not None:
+        selected_color = _select_score_color(score_color_map, score)
+
+    if selected_color:
+        return f'{prefix}<font color="{selected_color}">{body}</font>'
     return f"{prefix}<u>{body}</u>"
+
+
+def _parse_score_color_map(raw: str) -> list[tuple[float, str]]:
+    """Parse a score-to-color mapping string into a sorted list.
+
+    Input format: ``"0:gray,0.5:yellow,0.8:green"``
+    Thresholds must be numeric; the result is sorted by threshold ascending.
+    """
+    if not raw:
+        return []
+    mapping = []
+    for part in raw.split(","):
+        if ":" not in part:
+            raise ValueError(
+                f"Invalid score color mapping: {part!r}. Expected format: 'threshold:color'.")
+        threshold, color = part.split(":", 1)
+        mapping.append((float(threshold.strip()), color.strip()))
+    mapping.sort(key=lambda x: x[0])
+    return mapping
+
+
+def _select_score_color(score_color_map: list[tuple[float, str]], score: float) -> Optional[str]:
+    """Select the color for a given score from a sorted threshold mapping.
+
+    The first threshold that is strictly greater than the score determines
+    the color.  If the score is greater than or equal to all thresholds,
+    the last color is used.
+    """
+    if not score_color_map:
+        return None
+    for threshold, color in score_color_map:
+        if score < threshold:
+            return color
+    return score_color_map[-1][1]
 
 
 def format_timestamp(
@@ -272,6 +320,8 @@ class SubtitlesWriter(ResultWriter):
         max_line_count: Optional[int] = options["max_line_count"]
         highlight_words: bool = options["highlight_words"]
         highlight_color: Optional[str] = options.get("highlight_color")
+        highlight_score_colors_raw: Optional[str] = options.get("highlight_score_colors")
+        score_color_map = _parse_score_color_map(highlight_score_colors_raw) if highlight_score_colors_raw else None
         max_line_width = 1000 if raw_max_line_width is None else raw_max_line_width
         preserve_segments = max_line_count is None or raw_max_line_width is None
 
@@ -351,7 +401,7 @@ class SubtitlesWriter(ResultWriter):
 
                 if highlight_words and has_timing:
                     last = subtitle_start
-                    all_words = [timing["word"] for timing in subtitle]
+                    all_words = list(subtitle)
                     for i, this_word in enumerate(subtitle):
                         if "start" in this_word:
                             start = self.format_timestamp(this_word["start"])
@@ -361,7 +411,13 @@ class SubtitlesWriter(ResultWriter):
 
                             yield start, end, prefix + " ".join(
                                 [
-                                    _apply_highlight(word, highlight_color, is_current=(j == i))
+                                    _apply_highlight(
+                                        word["word"],
+                                        highlight_color,
+                                        is_current=(j == i),
+                                        score_color_map=score_color_map,
+                                        score=word.get("score"),
+                                    )
                                     for j, word in enumerate(all_words)
                                 ]
                             )


### PR DESCRIPTION
Closes #415

This PR adds two CLI options for customizing word-level highlight in SRT/VTT outputs:

- `--highlight_color`: single color for all highlighted words.
- `--highlight_score_colors`: map alignment confidence scores to colors (e.g. `0.3:red,0.7:yellow,1.0:green`).

### Usage

```bash
# fixed color
whisperx audio.wav --highlight_words True --highlight_color red

# hex color
whisperx audio.wav --highlight_words True --highlight_color "#00ff00"

# confidence-based coloring
whisperx audio.wav --highlight_words True --highlight_score_colors "0.3:red,0.7:yellow,1.0:green"
```

### Behavior

- When `--highlight_color` is set, highlighted words are wrapped in `<font color="...">` instead of the legacy `<u>` tag.
- `--highlight_score_colors` overrides the color per word based on the alignment score. Words without a score fall back to `--highlight_color`.
- No color set → legacy `<u>` underline, preserving backward compatibility.

### Tests

Added `tests/test_highlight_color.py` covering:
- single-color and hex rendering
- score-color map parsing and selection
- integration with VTT/SRT output
- tag balance for both `<font>` and `<u>` tags
