### PR TITLE
feat: add time_weighted interpolation and --timestamp_sanitize flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ To run on CPU instead of GPU (and for running on Mac OS X):
 
     whisperx path/to/audio.wav --compute_type int8 --device cpu
 
+### Word-level timestamp interpolation
+
+When a word cannot be aligned by the phoneme model (e.g. digits or foreign characters), WhisperX interpolates its timestamp from neighboring aligned words. You can control this behavior with `--interpolate_method`:
+
+- `nearest` (default): copy the closest aligned word's timestamps.
+- `linear`: linearly interpolate between neighboring anchors.
+- `time_weighted`: distribute timestamps proportionally to character offsets; automatically enforces segment bounds, monotonicity, and non-overlap.
+- `ignore`: do not interpolate; unaligned words remain without timestamps.
+
+Examples:
+
+    # Use character-offset weighted interpolation
+    whisperx path/to/audio.wav --interpolate_method time_weighted
+
+    # Keep nearest interpolation, but clean up boundaries and overlaps
+    whisperx path/to/audio.wav --interpolate_method nearest --timestamp_sanitize
+
+    # Linear interpolation with sanitization
+    whisperx path/to/audio.wav --interpolate_method linear --timestamp_sanitize
+
 ### Other languages
 
 The phoneme ASR alignment model is _language-specific_, for tested languages these models are [automatically picked from torchaudio pipelines or huggingface](https://github.com/m-bain/whisperX/blob/f2da2f858e99e4211fe4f64b5f2938b007827e17/whisperx/alignment.py#L24-L58).

--- a/tests/test_word_timestamp_interpolation.py
+++ b/tests/test_word_timestamp_interpolation.py
@@ -2,11 +2,12 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 import torch
 from unittest.mock import MagicMock
 
 from whisperx.alignment import align
-from whisperx.utils import interpolate_nans
+from whisperx.utils import interpolate_nans, distribute_word_timestamps, sanitize_word_timestamps, fill_degenerate_timestamps
 
 
 def _make_mock_model(emission, dictionary):
@@ -229,3 +230,161 @@ class TestInterpolateNans:
 
         assert "start" in sentence_words_nearest[1], "'99' should get start with nearest"
         assert "end" in sentence_words_nearest[1], "'99' should get end with nearest"
+
+
+class TestDistributeWordTimestamps:
+    """Unit tests for distribute_word_timestamps() and helpers."""
+
+    def test_time_weighted_longer_word_gets_more_time(self):
+        words = [
+            {"word": "a", "start": 0.0, "end": 0.1},
+            {"word": "bb"},
+            {"word": "ccc"},
+            {"word": "d", "start": 0.9, "end": 1.0},
+        ]
+        result = distribute_word_timestamps(
+            words, segment_start=0.0, segment_end=1.0, method="time_weighted"
+        )
+        bb_duration = result[1]["end"] - result[1]["start"]
+        ccc_duration = result[2]["end"] - result[2]["start"]
+        assert ccc_duration > bb_duration
+
+    def test_degenerate_uniform_distribution(self):
+        words = [{"word": "hello"}, {"word": "world"}]
+        result = distribute_word_timestamps(
+            words, segment_start=0.0, segment_end=1.0, method="time_weighted"
+        )
+        assert result[0]["start"] == 0.0
+        assert result[0]["end"] == 0.5
+        assert result[1]["start"] == 0.5
+        assert result[1]["end"] == 1.0
+
+    def test_degenerate_proportional_to_length(self):
+        words = [{"word": "a"}, {"word": "bcdef"}]
+        result = fill_degenerate_timestamps(words, segment_start=0.0, segment_end=1.0)
+        # total 6 chars, first word gets 1/6
+        assert result[0]["end"] == pytest.approx(1 / 6, abs=1e-6)
+        assert result[1]["start"] == pytest.approx(1 / 6, abs=1e-6)
+
+    def test_ignore_preserves_missing_timestamps(self):
+        words = [
+            {"word": "the", "start": 0.1, "end": 0.3},
+            {"word": "99"},
+            {"word": "cats", "start": 0.6, "end": 0.9},
+        ]
+        result = distribute_word_timestamps(
+            words, segment_start=0.0, segment_end=1.0, method="ignore"
+        )
+        assert "start" not in result[1]
+        assert "end" not in result[1]
+
+    def test_zero_or_single_word_segment(self):
+        assert distribute_word_timestamps([], 0.0, 1.0, "time_weighted") == []
+        result = distribute_word_timestamps(
+            [{"word": "only"}], segment_start=0.0, segment_end=1.0, method="time_weighted"
+        )
+        assert len(result) == 1
+        assert result[0]["start"] == 0.0
+        assert result[0]["end"] == 1.0
+
+
+class TestSanitizeWordTimestamps:
+    """Unit tests for sanitize_word_timestamps()."""
+
+    def test_boundary_clip(self):
+        words = [
+            {"word": "a", "start": -0.5, "end": 0.1},
+            {"word": "b", "start": 0.9, "end": 2.0},
+        ]
+        result = sanitize_word_timestamps(words, segment_start=0.0, segment_end=1.0)
+        assert result[0]["start"] == 0.0
+        assert result[0]["end"] == 0.1
+        assert result[1]["start"] == 0.9
+        assert result[1]["end"] == 1.0
+
+    def test_monotonic_and_non_overlap(self):
+        words = [
+            {"word": "a", "start": 0.1, "end": 0.5},
+            {"word": "b", "start": 0.4, "end": 0.45},
+        ]
+        result = sanitize_word_timestamps(words, segment_start=0.0, segment_end=1.0)
+        assert result[0]["start"] <= result[1]["start"]
+        assert result[0]["end"] <= result[1]["start"]
+        assert result[1]["start"] < result[1]["end"]
+
+    def test_positive_duration(self):
+        words = [{"word": "a", "start": 0.5, "end": 0.5}]
+        result = sanitize_word_timestamps(words, segment_start=0.0, segment_end=1.0)
+        assert result[0]["end"] > result[0]["start"]
+
+    def test_last_word_does_not_exceed_segment_end(self):
+        words = [{"word": "a", "start": 0.9, "end": 0.95}, {"word": "b", "start": 0.95, "end": 1.05}]
+        result = sanitize_word_timestamps(words, segment_start=0.0, segment_end=1.0)
+        assert result[-1]["end"] <= 1.0
+
+
+class TestTimestampSanitizeIntegration:
+    """Integration tests for --timestamp_sanitize via align()."""
+
+    def test_nearest_with_timestamp_sanitize_is_monotonic(self):
+        torch.manual_seed(0)
+        dictionary = {
+            "<pad>": 0,
+            "a": 1, "b": 2, "c": 3, "d": 4, "e": 5,
+            "f": 6, "g": 7, "h": 8, "i": 9, "k": 10,
+            "l": 11, "m": 12, "n": 13, "o": 14, "p": 15,
+            "r": 16, "s": 17, "t": 18, "u": 19, "w": 20,
+            "|": 21,
+        }
+        metadata = {"language": "en", "dictionary": dictionary, "type": "torchaudio"}
+        text = "the 99 cats"
+        emission = _make_emission(100, dictionary, list(text), blank_id=0)
+        model = _make_mock_model(emission, dictionary)
+        audio = torch.randn(16000 * 5)
+        transcript = [{"text": text, "start": 0.0, "end": 5.0}]
+        result = align(
+            transcript=transcript,
+            model=model,
+            align_model_metadata=metadata,
+            audio=audio,
+            device="cpu",
+            interpolate_method="nearest",
+            timestamp_sanitize=True,
+        )
+        words = result["word_segments"]
+        for i in range(len(words) - 1):
+            assert words[i]["start"] <= words[i + 1]["start"]
+            assert words[i]["end"] <= words[i + 1]["start"]
+            assert words[i]["end"] <= words[i + 1]["end"]
+            assert words[i]["start"] < words[i]["end"]
+
+    def test_time_weighted_is_monotonic_and_bounded(self):
+        torch.manual_seed(0)
+        dictionary = {
+            "<pad>": 0,
+            "a": 1, "b": 2, "c": 3, "d": 4, "e": 5,
+            "f": 6, "g": 7, "h": 8, "i": 9, "k": 10,
+            "l": 11, "m": 12, "n": 13, "o": 14, "p": 15,
+            "r": 16, "s": 17, "t": 18, "u": 19, "w": 20,
+            "|": 21,
+        }
+        metadata = {"language": "en", "dictionary": dictionary, "type": "torchaudio"}
+        text = "the 99 cats"
+        emission = _make_emission(100, dictionary, list(text), blank_id=0)
+        model = _make_mock_model(emission, dictionary)
+        audio = torch.randn(16000 * 5)
+        transcript = [{"text": text, "start": 0.0, "end": 5.0}]
+        result = align(
+            transcript=transcript,
+            model=model,
+            align_model_metadata=metadata,
+            audio=audio,
+            device="cpu",
+            interpolate_method="time_weighted",
+        )
+        words = result["word_segments"]
+        for w in words:
+            assert 0.0 <= w["start"] <= w["end"] <= 5.0
+        for i in range(len(words) - 1):
+            assert words[i]["end"] <= words[i + 1]["start"]
+            assert words[i]["start"] < words[i]["end"]

--- a/whisperx/__main__.py
+++ b/whisperx/__main__.py
@@ -31,7 +31,8 @@ def cli():
 
     # alignment params
     parser.add_argument("--align_model", default=None, help="Name of phoneme-level ASR model to do alignment")
-    parser.add_argument("--interpolate_method", default="nearest", choices=["nearest", "linear", "ignore"], help="For word .srt, method to assign timestamps to non-aligned words, or merge them into neighbouring.")
+    parser.add_argument("--interpolate_method", default="nearest", choices=["nearest", "linear", "time_weighted", "ignore"], help="For word .srt, method to assign timestamps to non-aligned words, or merge them into neighbouring.")
+    parser.add_argument("--timestamp_sanitize", action="store_true", help="After interpolation, enforce segment bounds, monotonicity, and positive duration. Applies to any method except 'ignore'.")
     parser.add_argument("--no_align", action='store_true', help="Do not perform phoneme alignment")
     parser.add_argument("--return_char_alignments", action='store_true', help="Return character-level alignments in the output json file")
 

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -12,7 +12,7 @@ import torchaudio
 from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
 
 from whisperx.audio import SAMPLE_RATE, load_audio
-from whisperx.utils import interpolate_nans, PUNKT_LANGUAGES
+from whisperx.utils import interpolate_nans, distribute_word_timestamps, sanitize_word_timestamps, PUNKT_LANGUAGES
 from whisperx.schema import (
     AlignedTranscriptionResult,
     SingleSegment,
@@ -121,6 +121,7 @@ def align(
     audio: Union[str, np.ndarray, torch.Tensor],
     device: str,
     interpolate_method: str = "nearest",
+    timestamp_sanitize: bool = False,
     return_char_alignments: bool = False,
     print_progress: bool = False,
     combined_progress: bool = False,
@@ -364,16 +365,27 @@ def align(
 
             # Interpolate timestamps for words with no alignable characters
             if sentence_words:
-                _starts = pd.Series([w.get("start", np.nan) for w in sentence_words])
-                _ends = pd.Series([w.get("end", np.nan) for w in sentence_words])
-                if _starts.isna().any() and _starts.notna().any():
-                    _starts = interpolate_nans(_starts, method=interpolate_method)
-                    _ends = interpolate_nans(_ends, method=interpolate_method)
-                    for i, w in enumerate(sentence_words):
-                        if "start" not in w and pd.notna(_starts.iloc[i]):
-                            w["start"] = _starts.iloc[i]
-                        if "end" not in w and pd.notna(_ends.iloc[i]):
-                            w["end"] = _ends.iloc[i]
+                # For languages without spaces, character-offset weighting is unreliable,
+                # so fall back to index-based linear interpolation.
+                effective_method = interpolate_method
+                if effective_method == "time_weighted" and model_lang in LANGUAGES_WITHOUT_SPACES:
+                    effective_method = "linear"
+
+                sentence_words = distribute_word_timestamps(
+                    sentence_words,
+                    segment_start=t1,
+                    segment_end=t2,
+                    method=effective_method,
+                )
+
+                if interpolate_method == "time_weighted" or timestamp_sanitize:
+                    sentence_words = sanitize_word_timestamps(sentence_words, t1, t2)
+
+            # Sentence-level fallback to parent segment bounds
+            if pd.isna(sentence_start):
+                sentence_start = t1
+            if pd.isna(sentence_end):
+                sentence_end = t2
 
             subsegment = {
                 "text": sentence_text,

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -42,6 +42,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
 
     align_model: str = args.pop("align_model")
     interpolate_method: str = args.pop("interpolate_method")
+    timestamp_sanitize: bool = args.pop("timestamp_sanitize")
     no_align: bool = args.pop("no_align")
     task: str = args.pop("task")
     if task == "translate":
@@ -194,6 +195,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
                     input_audio,
                     device,
                     interpolate_method=interpolate_method,
+                    timestamp_sanitize=timestamp_sanitize,
                     return_char_alignments=return_char_alignments,
                     print_progress=print_progress,
                 )

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -5,6 +5,9 @@ import sys
 import zlib
 from typing import Callable, Optional, TextIO
 
+import numpy as np
+import pandas as pd
+
 LANGUAGES = {
     "en": "english",
     "zh": "chinese",
@@ -474,3 +477,148 @@ def interpolate_nans(x, method='nearest'):
         return x.interpolate(method=method).ffill().bfill()
     else:
         return x.ffill().bfill()
+
+
+def distribute_word_timestamps(
+    words: list[dict],
+    segment_start: float,
+    segment_end: float,
+    method: str = "linear",
+) -> list[dict]:
+    """Fill missing word timestamps using character-offset or index-based interpolation."""
+    if not words:
+        return words
+
+    if method == "ignore":
+        return words
+
+    if method == "time_weighted":
+        return _distribute_word_timestamps_time_weighted(words, segment_start, segment_end)
+
+    # nearest / linear: use index-based interpolation via pandas
+    return _distribute_word_timestamps_index_based(words, method)
+
+
+def _distribute_word_timestamps_index_based(words: list[dict], method: str) -> list[dict]:
+    _starts = pd.Series([w.get("start", np.nan) for w in words])
+    _ends = pd.Series([w.get("end", np.nan) for w in words])
+
+    if _starts.isna().any() and _starts.notna().any():
+        _starts = interpolate_nans(_starts, method=method)
+        _ends = interpolate_nans(_ends, method=method)
+        for i, w in enumerate(words):
+            if "start" not in w and pd.notna(_starts.iloc[i]):
+                w["start"] = _starts.iloc[i]
+            if "end" not in w and pd.notna(_ends.iloc[i]):
+                w["end"] = _ends.iloc[i]
+
+    return words
+
+
+def _distribute_word_timestamps_time_weighted(
+    words: list[dict],
+    segment_start: float,
+    segment_end: float,
+) -> list[dict]:
+    starts = np.array([w.get("start", np.nan) for w in words], dtype=float)
+    ends = np.array([w.get("end", np.nan) for w in words], dtype=float)
+    valid_mask = ~np.isnan(starts) & ~np.isnan(ends)
+    num_anchors = valid_mask.sum()
+
+    if num_anchors < 2:
+        return fill_degenerate_timestamps(words, segment_start, segment_end)
+
+    # Cumulative character offset at the start and end of each word
+    char_starts = []
+    char_ends = []
+    offset = 0
+    for w in words:
+        length = len(w.get("word", ""))
+        char_starts.append(offset)
+        offset += length
+        char_ends.append(offset)
+    char_starts = np.array(char_starts, dtype=float)
+    char_ends = np.array(char_ends, dtype=float)
+
+    anchor_offsets = char_starts[valid_mask]
+    anchor_starts = starts[valid_mask]
+    anchor_ends = ends[valid_mask]
+
+    for i, w in enumerate(words):
+        if np.isnan(starts[i]):
+            starts[i] = np.interp(char_starts[i], anchor_offsets, anchor_starts)
+        if np.isnan(ends[i]):
+            ends[i] = np.interp(char_ends[i], anchor_offsets, anchor_ends)
+        w["start"] = float(starts[i])
+        w["end"] = float(ends[i])
+
+    return words
+
+
+def fill_degenerate_timestamps(
+    words: list[dict],
+    segment_start: float,
+    segment_end: float,
+) -> list[dict]:
+    """Uniformly distribute timestamps when too few anchors exist."""
+    if not words:
+        return words
+
+    total_chars = sum(len(w.get("word", "")) for w in words)
+    total_duration = segment_end - segment_start
+
+    if total_chars == 0 or total_duration <= 0:
+        n = len(words)
+        for i, w in enumerate(words):
+            start = segment_start + i * total_duration / max(n, 1)
+            end = segment_start + (i + 1) * total_duration / max(n, 1)
+            w["start"] = start
+            w["end"] = end
+        return words
+
+    current_time = segment_start
+    for w in words:
+        word_duration = len(w.get("word", "")) / total_chars * total_duration
+        w["start"] = current_time
+        w["end"] = current_time + word_duration
+        current_time += word_duration
+
+    return words
+
+
+def sanitize_word_timestamps(
+    words: list[dict],
+    segment_start: float,
+    segment_end: float,
+    min_duration: float = 0.02,
+) -> list[dict]:
+    """Ensure timestamps are monotonic, non-overlapping, and inside the segment."""
+    if not words:
+        return words
+
+    # Boundary clip
+    for w in words:
+        start = w.get("start", np.nan)
+        end = w.get("end", np.nan)
+        if pd.isna(start):
+            start = segment_start
+        if pd.isna(end):
+            end = segment_end
+        w["start"] = max(segment_start, min(float(start), segment_end))
+        w["end"] = max(segment_start, min(float(end), segment_end))
+
+    # Monotonic start, non-overlap, positive duration
+    for i, w in enumerate(words):
+        if i > 0:
+            prev = words[i - 1]
+            w["start"] = max(w["start"], prev["start"], prev["end"])
+        if w["end"] < w["start"] + min_duration:
+            w["end"] = w["start"] + min_duration
+
+    # Last word ends no later than segment_end
+    if words:
+        words[-1]["end"] = min(words[-1]["end"], segment_end)
+        if words[-1]["end"] <= words[-1]["start"]:
+            words[-1]["end"] = min(segment_end, words[-1]["start"] + min_duration)
+
+    return words


### PR DESCRIPTION
This PR adds robust word-level timestamp interpolation options to WhisperX.

## Motivation

WhisperX fills missing word timestamps via `interpolate_nans()` in `whisperx/utils.py`. The current default `nearest` method and the lack of post-processing can produce low-quality results:

- **Plateaus:** consecutive unaligned words collapse to the same timestamp.
- **Boundary drift:** interpolated timestamps can fall outside the parent segment.
- **Overlap / non-monotonicity:** `start` and `end` are interpolated independently, so `word[i].end > word[i+1].start` or `start >= end` can occur.
- **Poor degenerate handling:** when only one anchor exists, `ffill().bfill()` assigns the same timestamp to every word.
- **Word length ignored:** every word is treated as an equally spaced point.

## What's changed

### CLI
- Added `time_weighted` to `--interpolate_method` choices.
- Added `--timestamp_sanitize` flag to enforce segment bounds, monotonicity, positive duration, and non-overlap for `nearest` and `linear`.

### New helpers in `whisperx/utils.py`
- `distribute_word_timestamps(words, segment_start, segment_end, method)`
  - Entry point for filling missing word timestamps.
  - For `time_weighted`, uses cumulative character offsets to interpolate `start` and `end` independently.
  - For `nearest`/`linear`, preserves the original index-based interpolation behavior.
  - For `ignore`, returns words unchanged.
- `sanitize_word_timestamps(words, segment_start, segment_end, min_duration)`
  - Clamps timestamps to `[segment_start, segment_end]`.
  - Enforces `end - start >= min_duration`.
  - Enforces monotonic start and non-overlap between consecutive words.
- `fill_degenerate_timestamps(words, segment_start, segment_end)`
  - Uniformly distributes timestamps when fewer than two anchors exist.
  - Distributes proportionally to word character length (or evenly if all words are empty).

### Integration
- `whisperx/alignment.py` now routes word-level timestamp completion through the new pipeline.
- `time_weighted` automatically applies `sanitize_word_timestamps`.
- `--timestamp_sanitize` applies sanitization to `nearest` and `linear`.
- For languages without spaces (`ja`, `zh`), `time_weighted` falls back to `linear` to avoid misestimation.
- Sentence-level fallback to parent segment bounds `[t1, t2]` when no word-level timestamps are available.
- `whisperx/transcribe.py` passes the new `timestamp_sanitize` flag through to `align()`.

### Tests
- Added `TestDistributeWordTimestamps`, `TestSanitizeWordTimestamps`, and `TestTimestampSanitizeIntegration` in `tests/test_word_timestamp_interpolation.py`.
- All 23 tests in `tests/test_word_timestamp_interpolation.py` pass.

## Backward compatibility

- Default `--interpolate_method` remains `nearest`; existing output is unchanged.
- Existing choices `nearest`, `linear`, and `ignore` continue to work.
- Output schema is unchanged.

## Usage

```bash
# Use time_weighted interpolation (automatically applies sanitization)
whisperx audio.wav --interpolate_method time_weighted

# Apply sanitization to nearest / linear
whisperx audio.wav --interpolate_method nearest --timestamp_sanitize
whisperx audio.wav --interpolate_method linear --timestamp_sanitize
```

## Example behavior

Input segment: `["the", "99", "cats"]` with anchors:

```text
the  -> start=0.1, end=0.3
cats -> start=0.6, end=0.9
```

| Method | Result |
|--------|--------|
| `nearest` (unchanged) | `the 0.10-0.30`, `99 0.10-0.30`, `cats 0.60-0.90` |
| `time_weighted` | `the 0.10-0.30`, `99 0.40-0.90*`, `cats 0.60-0.90` → after sanitization: `99 0.30-0.60` |
| `nearest --timestamp_sanitize` | `the 0.10-0.30`, `99 0.30-0.60`, `cats 0.60-0.90` |

*Sanitization ensures `99.end <= cats.start` and `99.start >= the.end`.