### PR TITLE
feat: Optimize alignment post-processing with NumPy

### DIFF
--- a/tests/test_word_timestamp_interpolation.py
+++ b/tests/test_word_timestamp_interpolation.py
@@ -1,11 +1,13 @@
 """Test that align() produces word-level timestamps for unalignable characters."""
 
-import numpy as np
-import pandas as pd
-import torch
 from unittest.mock import MagicMock
 
-from whisperx.alignment import align
+import numpy as np
+import pytest
+import torch
+
+from whisperx.alignment import _get_aligned_subsegments, _get_sentence_words, align
+from whisperx.schema import CharAlignmentArrays
 from whisperx.utils import interpolate_nans
 
 
@@ -49,6 +51,47 @@ def _make_emission(num_frames, dictionary, transcript_chars, blank_id=0):
                 emission[t, blank_id] = -3.0  # suppress blank
 
     return emission
+
+
+def test_sentence_words_are_aggregated_from_character_arrays():
+    alignments = CharAlignmentArrays(
+        chars=list("hi all"),
+        starts=np.array([0.0, 0.1, np.nan, 0.3, 0.4, 0.5]),
+        ends=np.array([0.1, 0.2, np.nan, 0.4, 0.5, 0.6]),
+        scores=np.array([0.9, 0.7, np.nan, 0.6, 0.8, 1.0]),
+        word_ids=np.array([0, 0, 0, 1, 1, 1]),
+    )
+
+    assert _get_sentence_words(alignments, 0, len(alignments.chars)) == [
+        {"word": "hi", "start": 0.0, "end": 0.2, "score": 0.8},
+        {"word": "all", "start": 0.3, "end": 0.6, "score": 0.8},
+    ]
+
+
+def test_aligned_subsegments_include_optional_metadata():
+    alignments = CharAlignmentArrays(
+        chars=list("你好吗"),
+        starts=np.array([0.0, 0.5, 1.0]),
+        ends=np.array([0.5, 1.0, 1.5]),
+        scores=np.array([0.9, 0.7, 0.8]),
+        word_ids=np.array([0, 1, 2]),
+    )
+
+    segments = _get_aligned_subsegments(
+        alignments,
+        sentence_spans=[(0, 3)],
+        text="你好吗",
+        model_lang="zh",
+        interpolate_method="nearest",
+        return_char_alignments=True,
+        avg_logprob=-0.25,
+    )
+
+    assert segments[0]["text"] == "你好吗"
+    assert (segments[0]["start"], segments[0]["end"]) == (0.0, 1.5)
+    assert segments[0]["avg_logprob"] == -0.25
+    assert [word["word"] for word in segments[0]["words"]] == list("你好吗")
+    assert [char["char"] for char in segments[0]["chars"]] == list("你好吗")
 
 
 class TestAlignWithWildcards:
@@ -174,23 +217,48 @@ class TestAlignWithWildcards:
 class TestInterpolateNans:
     """Unit tests for interpolate_nans()."""
 
-    def test_ignore_preserves_nans(self):
-        x = pd.Series([1.0, np.nan, 3.0, np.nan, 5.0])
-        result = interpolate_nans(x, method="ignore")
-        assert result is x
-        assert result.isna().sum() == 2
+    @pytest.mark.parametrize(
+        ("method", "expected"),
+        [
+            ("nearest", [1.0, 1.0, 1.0, 4.0, 4.0, 4.0]),
+            ("linear", [1.0, 1.0, 2.0, 3.0, 4.0, 4.0]),
+            ("ignore", [np.nan, 1.0, np.nan, np.nan, 4.0, np.nan]),
+        ],
+    )
+    def test_interpolation_methods(self, method, expected):
+        actual = interpolate_nans([np.nan, 1.0, np.nan, np.nan, 4.0, np.nan], method)
+        np.testing.assert_equal(actual, expected)
 
-    def test_nearest_fills_nans(self):
-        x = pd.Series([1.0, np.nan, 3.0, np.nan, 5.0])
-        result = interpolate_nans(x, method="nearest")
-        assert result.notna().all()
+    @pytest.mark.parametrize(
+        ("values", "expected"),
+        [
+            ([np.nan, np.nan], [np.nan, np.nan]),
+            ([np.nan, 2.0, np.nan], [2.0, 2.0, 2.0]),
+        ],
+    )
+    def test_sparse_known_values(self, values, expected):
+        np.testing.assert_equal(interpolate_nans(values), expected)
+
+    @pytest.mark.parametrize("method", ["linear", "nearest"])
+    def test_complete_input_is_unchanged(self, method):
+        values = [1.0, 2.0, 3.0]
+        np.testing.assert_equal(interpolate_nans(values, method), values)
+
+    def test_does_not_mutate_input(self):
+        values = np.array([1.0, np.nan, 3.0])
+        interpolate_nans(values)
+        np.testing.assert_equal(values, [1.0, np.nan, 3.0])
+
+    def test_rejects_unknown_method(self):
+        with pytest.raises(ValueError, match="Invalid interpolation method"):
+            interpolate_nans([np.nan, np.nan], "cubic")
 
     def test_ignore_word_assignment_integration(self):
         """Simulate the word-timestamp assignment logic from alignment.py:365-376.
 
         With wildcard CTC, this path is rarely reached in practice, but it's
         the code that "ignore" is designed to affect. This test proves the
-        pieces fit together: interpolate_nans preserves NaN, and the pd.notna
+        pieces fit together: interpolate_nans preserves NaN, and the NaN
         guard prevents timestamp assignment to unaligned words.
         """
         sentence_words = [
@@ -198,17 +266,17 @@ class TestInterpolateNans:
             {"word": "99"},  # simulates a word with no CTC timestamps
             {"word": "cats", "start": 0.6, "end": 0.9},
         ]
-        _starts = pd.Series([0.1, np.nan, 0.6])
-        _ends = pd.Series([0.3, np.nan, 0.9])
+        _starts = np.array([0.1, np.nan, 0.6])
+        _ends = np.array([0.3, np.nan, 0.9])
 
         # With "ignore": NaNs preserved, unaligned word stays without timestamps
         _starts_ign = interpolate_nans(_starts, method="ignore")
         _ends_ign = interpolate_nans(_ends, method="ignore")
         for i, w in enumerate(sentence_words):
-            if "start" not in w and pd.notna(_starts_ign.iloc[i]):
-                w["start"] = _starts_ign.iloc[i]
-            if "end" not in w and pd.notna(_ends_ign.iloc[i]):
-                w["end"] = _ends_ign.iloc[i]
+            if "start" not in w and not np.isnan(_starts_ign[i]):
+                w["start"] = _starts_ign[i]
+            if "end" not in w and not np.isnan(_ends_ign[i]):
+                w["end"] = _ends_ign[i]
 
         assert "start" not in sentence_words[1], "'99' should not get start with ignore"
         assert "end" not in sentence_words[1], "'99' should not get end with ignore"
@@ -222,10 +290,10 @@ class TestInterpolateNans:
         _starts_nr = interpolate_nans(_starts.copy(), method="nearest")
         _ends_nr = interpolate_nans(_ends.copy(), method="nearest")
         for i, w in enumerate(sentence_words_nearest):
-            if "start" not in w and pd.notna(_starts_nr.iloc[i]):
-                w["start"] = _starts_nr.iloc[i]
-            if "end" not in w and pd.notna(_ends_nr.iloc[i]):
-                w["end"] = _ends_nr.iloc[i]
+            if "start" not in w and not np.isnan(_starts_nr[i]):
+                w["start"] = _starts_nr[i]
+            if "end" not in w and not np.isnan(_ends_nr[i]):
+                w["end"] = _ends_nr[i]
 
         assert "start" in sentence_words_nearest[1], "'99' should get start with nearest"
         assert "end" in sentence_words_nearest[1], "'99' should get end with nearest"

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -6,15 +6,15 @@ from dataclasses import dataclass
 from typing import Iterable, Optional, Union, List
 
 import numpy as np
-import pandas as pd
 import torch
 import torchaudio
 from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
 
 from whisperx.audio import SAMPLE_RATE, load_audio
-from whisperx.utils import interpolate_nans, PUNKT_LANGUAGES
+from whisperx.utils import PUNKT_LANGUAGES, interpolate_nans
 from whisperx.schema import (
     AlignedTranscriptionResult,
+    CharAlignmentArrays,
     SingleSegment,
     SingleAlignedSegment,
     SingleWordSegment,
@@ -75,6 +75,126 @@ DEFAULT_ALIGN_MODELS_HF = {
     "sv": "KBLab/wav2vec2-large-voxrex-swedish",
     "id": "cahya/wav2vec2-large-xlsr-indonesian",
 }
+
+
+def _get_sentence_words(
+    alignments: CharAlignmentArrays,
+    start: int,
+    stop: int,
+) -> list[dict]:
+    sentence_words = []
+    word_start = start
+    while word_start < stop:
+        word_id = alignments.word_ids[word_start]
+        word_stop = word_start + 1
+        while word_stop < stop and alignments.word_ids[word_stop] == word_id:
+            word_stop += 1
+
+        word_text = "".join(alignments.chars[word_start:word_stop]).strip()
+        if word_text:
+            aligned_indices = [
+                index
+                for index in range(word_start, word_stop)
+                if alignments.chars[index] != " "
+            ]
+            word_start_time = np.nanmin(alignments.starts[aligned_indices])
+            word_end_time = np.nanmax(alignments.ends[aligned_indices])
+            word_score = round(np.nanmean(alignments.scores[aligned_indices]), 3)
+
+            word_segment = {"word": word_text}
+            if not np.isnan(word_start_time):
+                word_segment["start"] = word_start_time
+            if not np.isnan(word_end_time):
+                word_segment["end"] = word_end_time
+            if not np.isnan(word_score):
+                word_segment["score"] = word_score
+            sentence_words.append(word_segment)
+        word_start = word_stop
+    return sentence_words
+
+
+def _get_aligned_subsegments(
+    alignments: CharAlignmentArrays,
+    sentence_spans: list[tuple[int, int]],
+    text: str,
+    model_lang: str,
+    interpolate_method: str,
+    return_char_alignments: bool,
+    avg_logprob: Optional[float],
+) -> list[SingleAlignedSegment]:
+    aligned_subsegments = []
+    for sstart, send in sentence_spans:
+        # Preserve the existing inclusive character selection at `send`,
+        # while sentence text itself uses Punkt's exclusive end offset.
+        char_stop = min(send + 1, len(alignments.chars))
+        sentence_start = np.nanmin(alignments.starts[sstart:char_stop])
+        non_space_indices = [
+            index
+            for index in range(sstart, char_stop)
+            if alignments.chars[index] != " "
+        ]
+        sentence_end = np.nanmax(alignments.ends[non_space_indices])
+        sentence_words = _get_sentence_words(alignments, sstart, char_stop)
+
+        if sentence_words:
+            word_starts = [word.get("start", np.nan) for word in sentence_words]
+            word_ends = [word.get("end", np.nan) for word in sentence_words]
+            if np.isnan(word_starts).any() and not np.isnan(word_starts).all():
+                word_starts = interpolate_nans(word_starts, interpolate_method)
+                word_ends = interpolate_nans(word_ends, interpolate_method)
+                for index, word in enumerate(sentence_words):
+                    if "start" not in word and not np.isnan(word_starts[index]):
+                        word["start"] = float(word_starts[index])
+                    if "end" not in word and not np.isnan(word_ends[index]):
+                        word["end"] = float(word_ends[index])
+
+        subsegment: SingleAlignedSegment = {
+            "text": text[sstart:send],
+            "start": sentence_start,
+            "end": sentence_end,
+            "words": sentence_words,
+        }
+        if avg_logprob is not None:
+            subsegment["avg_logprob"] = avg_logprob
+        if return_char_alignments:
+            sentence_chars = []
+            for index in range(sstart, char_stop):
+                char = {"char": alignments.chars[index]}
+                if not np.isnan(alignments.starts[index]):
+                    char["start"] = float(alignments.starts[index])
+                if not np.isnan(alignments.ends[index]):
+                    char["end"] = float(alignments.ends[index])
+                if not np.isnan(alignments.scores[index]):
+                    char["score"] = float(alignments.scores[index])
+                sentence_chars.append(char)
+            subsegment["chars"] = sentence_chars
+        aligned_subsegments.append(subsegment)
+
+    starts = interpolate_nans(
+        [segment["start"] for segment in aligned_subsegments],
+        interpolate_method,
+    )
+    ends = interpolate_nans(
+        [segment["end"] for segment in aligned_subsegments],
+        interpolate_method,
+    )
+
+    separator = "" if model_lang in LANGUAGES_WITHOUT_SPACES else " "
+    grouped: dict[tuple[float, float], SingleAlignedSegment] = {}
+    for segment, start, end in zip(aligned_subsegments, starts, ends, strict=True):
+        if np.isnan(start) or np.isnan(end):
+            continue
+        key = (float(start), float(end))
+        if key not in grouped:
+            segment["start"], segment["end"] = key
+            grouped[key] = segment
+            continue
+        grouped_segment = grouped[key]
+        grouped_segment["text"] += separator + segment["text"]
+        grouped_segment["words"].extend(segment["words"])
+        if return_char_alignments:
+            grouped_segment["chars"].extend(segment["chars"])
+    return [grouped[key] for key in sorted(grouped)]
 
 
 def load_align_model(language_code: str, device: str, model_name: Optional[str] = None, model_dir=None, model_cache_only: bool = False):
@@ -302,115 +422,35 @@ def align(
         ratio = duration * waveform_segment.size(0) / (trellis.size(0) - 1)
 
         # assign timestamps to aligned characters
-        char_segments_arr = []
+        chars = list(text)
+        starts = np.full(len(chars), np.nan, dtype=np.float64)
+        ends = np.full(len(chars), np.nan, dtype=np.float64)
+        scores = np.full(len(chars), np.nan, dtype=np.float64)
+        word_ids = np.empty(len(chars), dtype=np.int32)
+
+        for cdx, char_seg in zip(segment_data[sdx]["clean_cdx"], char_segments, strict=True):
+            starts[cdx] = round(char_seg.start * ratio + t1, 3)
+            ends[cdx] = round(char_seg.end * ratio + t1, 3)
+            scores[cdx] = round(char_seg.score, 3)
+
         word_idx = 0
-        for cdx, char in enumerate(text):
-            start, end, score = None, None, None
-            if cdx in segment_data[sdx]["clean_cdx"]:
-                char_seg = char_segments[segment_data[sdx]["clean_cdx"].index(cdx)]
-                start = round(char_seg.start * ratio + t1, 3)
-                end = round(char_seg.end * ratio + t1, 3)
-                score = round(char_seg.score, 3)
-
-            char_segments_arr.append(
-                {
-                    "char": char,
-                    "start": start,
-                    "end": end,
-                    "score": score,
-                    "word-idx": word_idx,
-                }
-            )
-
+        for cdx in range(len(chars)):
+            word_ids[cdx] = word_idx
             # increment word_idx, nltk word tokenization would probably be more robust here, but us space for now...
             if model_lang in LANGUAGES_WITHOUT_SPACES:
                 word_idx += 1
-            elif cdx == len(text) - 1 or text[cdx+1] == " ":
+            elif cdx == len(chars) - 1 or chars[cdx + 1] == " ":
                 word_idx += 1
 
-        char_segments_arr = pd.DataFrame(char_segments_arr)
-
-        aligned_subsegments = []
-        # assign sentence_idx to each character index
-        char_segments_arr["sentence-idx"] = None
-        for sdx2, (sstart, send) in enumerate(segment_data[sdx]["sentence_spans"]):
-            curr_chars = char_segments_arr.loc[(char_segments_arr.index >= sstart) & (char_segments_arr.index <= send)]
-            char_segments_arr.loc[(char_segments_arr.index >= sstart) & (char_segments_arr.index <= send), "sentence-idx"] = sdx2
-
-            sentence_text = text[sstart:send]
-            sentence_start = curr_chars["start"].min()
-            end_chars = curr_chars[curr_chars["char"] != ' ']
-            sentence_end = end_chars["end"].max()
-            sentence_words = []
-
-            for word_idx in curr_chars["word-idx"].unique():
-                word_chars = curr_chars.loc[curr_chars["word-idx"] == word_idx]
-                word_text = "".join(word_chars["char"].tolist()).strip()
-                if len(word_text) == 0:
-                    continue
-
-                # dont use space character for alignment
-                word_chars = word_chars[word_chars["char"] != " "]
-
-                word_start = word_chars["start"].min()
-                word_end = word_chars["end"].max()
-                word_score = round(word_chars["score"].mean(), 3)
-
-                # -1 indicates unalignable
-                word_segment = {"word": word_text}
-
-                if not np.isnan(word_start):
-                    word_segment["start"] = word_start
-                if not np.isnan(word_end):
-                    word_segment["end"] = word_end
-                if not np.isnan(word_score):
-                    word_segment["score"] = word_score
-
-                sentence_words.append(word_segment)
-
-            # Interpolate timestamps for words with no alignable characters
-            if sentence_words:
-                _starts = pd.Series([w.get("start", np.nan) for w in sentence_words])
-                _ends = pd.Series([w.get("end", np.nan) for w in sentence_words])
-                if _starts.isna().any() and _starts.notna().any():
-                    _starts = interpolate_nans(_starts, method=interpolate_method)
-                    _ends = interpolate_nans(_ends, method=interpolate_method)
-                    for i, w in enumerate(sentence_words):
-                        if "start" not in w and pd.notna(_starts.iloc[i]):
-                            w["start"] = _starts.iloc[i]
-                        if "end" not in w and pd.notna(_ends.iloc[i]):
-                            w["end"] = _ends.iloc[i]
-
-            subsegment = {
-                "text": sentence_text,
-                "start": sentence_start,
-                "end": sentence_end,
-                "words": sentence_words,
-            }
-            if avg_logprob is not None:
-                subsegment["avg_logprob"] = avg_logprob
-            aligned_subsegments.append(subsegment)
-
-            if return_char_alignments:
-                curr_chars = curr_chars[["char", "start", "end", "score"]]
-                curr_chars.fillna(-1, inplace=True)
-                curr_chars = curr_chars.to_dict("records")
-                curr_chars = [{key: val for key, val in char.items() if val != -1} for char in curr_chars]
-                aligned_subsegments[-1]["chars"] = curr_chars
-
-        aligned_subsegments = pd.DataFrame(aligned_subsegments)
-        aligned_subsegments["start"] = interpolate_nans(aligned_subsegments["start"], method=interpolate_method)
-        aligned_subsegments["end"] = interpolate_nans(aligned_subsegments["end"], method=interpolate_method)
-        # concatenate sentences with same timestamps
-        agg_dict = {"text": " ".join, "words": "sum"}
-        if model_lang in LANGUAGES_WITHOUT_SPACES:
-            agg_dict["text"] = "".join
-        if return_char_alignments:
-            agg_dict["chars"] = "sum"
-        if avg_logprob is not None:
-            agg_dict["avg_logprob"] = "first"
-        aligned_subsegments= aligned_subsegments.groupby(["start", "end"], as_index=False).agg(agg_dict)
-        aligned_subsegments = aligned_subsegments.to_dict('records')
+        aligned_subsegments = _get_aligned_subsegments(
+            CharAlignmentArrays(chars, starts, ends, scores, word_ids),
+            segment_data[sdx]["sentence_spans"],
+            text,
+            model_lang,
+            interpolate_method,
+            return_char_alignments,
+            avg_logprob,
+        )
         if progress_callback is not None:
             progress_callback(((sdx + 1) / total_segments) * 100)
 

--- a/whisperx/schema.py
+++ b/whisperx/schema.py
@@ -1,4 +1,6 @@
-from typing import Callable, TypedDict, Optional, List, Tuple
+from typing import Callable, NamedTuple, TypedDict, Optional, List, Tuple
+
+import numpy as np
 
 ProgressCallback = Optional[Callable[[float], None]]
 
@@ -47,6 +49,16 @@ class SegmentData(TypedDict):
     clean_cdx: List[int]   # Original indices of cleaned characters
     clean_wdx: List[int]   # Indices of words containing valid characters
     sentence_spans: List[Tuple[int, int]]  # Start and end indices of sentences
+
+
+class CharAlignmentArrays(NamedTuple):
+    """Columnar character alignment data indexed by transcript position."""
+
+    chars: List[str]
+    starts: np.ndarray
+    ends: np.ndarray
+    scores: np.ndarray
+    word_ids: np.ndarray
 
 
 class SingleAlignedSegment(TypedDict):

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -3,7 +3,9 @@ import os
 import re
 import sys
 import zlib
-from typing import Callable, Optional, TextIO
+from typing import Callable, Optional, Sequence, TextIO
+
+import numpy as np
 
 LANGUAGES = {
     "en": "english",
@@ -467,10 +469,34 @@ def get_writer(
         return optional_writers[output_format](output_dir)
     return writers[output_format](output_dir)
 
-def interpolate_nans(x, method='nearest'):
+
+def interpolate_nans(
+    values: Sequence[float] | np.ndarray,
+    method: str = "nearest",
+) -> np.ndarray:
+    """Interpolate missing values in a one-dimensional array."""
+    if method not in {"ignore", "linear", "nearest"}:
+        raise ValueError(f"Invalid interpolation method: {method}")
+
+    result = np.array(values, dtype=np.float64, copy=True)
     if method == "ignore":
-        return x
-    if x.notnull().sum() > 1:
-        return x.interpolate(method=method).ffill().bfill()
-    else:
-        return x.ffill().bfill()
+        return result
+
+    known = np.flatnonzero(~np.isnan(result))
+    if known.size == 0:
+        return result
+    if known.size == 1:
+        result.fill(result[known[0]])
+        return result
+
+    missing = np.flatnonzero(np.isnan(result))
+    if method == "linear":
+        result[missing] = np.interp(missing, known, result[known])
+    elif method == "nearest":
+        right_positions = np.searchsorted(known, missing).clip(max=known.size - 1)
+        left_positions = (right_positions - 1).clip(min=0)
+        left = known[left_positions]
+        right = known[right_positions]
+        nearest = np.where(missing - left <= right - missing, left, right)
+        result[missing] = result[nearest]
+    return result


### PR DESCRIPTION
Replace pandas DataFrame operations in serial `align` post-processing with NumPy arrays and contiguous scans.

On a 2,202-clip / 3.00-hour H100 benchmark, alignment time fell from 102.71s to 80.34s (1.28x throughput).

Validation: output fingerprints match the pandas path; 21 alignment tests pass.

Addresses the pandas/post-processing portion of #219.

I have a follow up #1454  with batching the encoder portions to get an additional ~10% speedup, but it's less elegant right now so these Numpy improvements seem like the safest, highest return changes to start. Open to any feedback!