### PR TITLE
Batch forced-alignment inference

### DIFF
--- a/tests/test_alignment_batch.py
+++ b/tests/test_alignment_batch.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from whisperx import alignment
+
+
+ALIGN_METADATA = {
+    "dictionary": {"<pad>": 0, "a": 1, "b": 2},
+    "language": "en",
+    "type": "torchaudio",
+}
+
+
+class FixedEmissionModel(torch.nn.Module):
+    def forward(self, waveform, lengths=None):
+        logits = torch.tensor(
+            [[
+                [5.0, 0.0, 0.0],
+                [0.0, 5.0, 0.0],
+                [0.0, 5.0, 0.0],
+                [5.0, 0.0, 0.0],
+                [0.0, 0.0, 5.0],
+                [5.0, 0.0, 0.0],
+            ]],
+            device=waveform.device,
+        ).repeat(waveform.shape[0], 1, 1)
+        output_lengths = torch.full(
+            (waveform.shape[0],), logits.shape[1], device=waveform.device
+        )
+        return logits, output_lengths
+
+
+def test_batch_size_one_matches_serial(monkeypatch):
+    logits, _ = FixedEmissionModel()(torch.zeros(1, 960))
+    emission = torch.log_softmax(logits[0], dim=-1)
+    monkeypatch.setattr(
+        alignment, "_compute_emission", lambda *args, **kwargs: emission
+    )
+    monkeypatch.setattr(
+        alignment, "_compute_emission_batch", lambda waveforms, *args: [emission] * len(waveforms)
+    )
+    transcript = [{"start": 0.0, "end": 0.06, "text": "ab"}]
+
+    serial = alignment.align(
+        transcript, None, ALIGN_METADATA, torch.zeros(960), "cpu",
+        return_char_alignments=True,
+    )
+    batched = alignment.align_batch(
+        [transcript], None, ALIGN_METADATA, [torch.zeros(960)], "cpu", 1,
+        return_char_alignments=True,
+    )[0]
+
+    assert batched == serial
+
+
+def test_align_batch_sorts_by_duration_and_restores_input_order(monkeypatch):
+    acoustic_batches = []
+
+    def compute_batch(waveforms, model, model_type, device):
+        acoustic_batches.append([waveform.shape[-1] for waveform in waveforms])
+        return [torch.empty(1, 3) for _ in waveforms]
+
+    def finish(segment, *args, **kwargs):
+        return [{"start": segment["start"], "end": segment["end"],
+                 "text": segment["text"], "words": []}]
+
+    monkeypatch.setattr(alignment, "_compute_emission_batch", compute_batch)
+    monkeypatch.setattr(alignment, "_finish_alignment_segment", finish)
+    transcripts = [
+        [{"start": 0.0, "end": 0.03, "text": "a"}],
+        [{"start": 0.0, "end": 0.01, "text": "a"}],
+        [{"start": 0.0, "end": 0.02, "text": "b"}],
+    ]
+
+    results = alignment.align_batch(
+        transcripts,
+        model=None,
+        align_model_metadata=ALIGN_METADATA,
+        audio=[torch.zeros(480), torch.zeros(160), torch.zeros(320)],
+        device="cpu",
+        batch_size=2,
+    )
+
+    assert acoustic_batches == [[160, 320], [480]]
+    assert [result["segments"][0]["text"] for result in results] == ["a", "a", "b"]
+
+
+def test_align_batch_validates_inputs():
+    with pytest.raises(ValueError, match="same number"):
+        alignment.align_batch([], None, ALIGN_METADATA, [torch.zeros(1)], "cpu", 1)
+    with pytest.raises(ValueError, match="at least 1"):
+        alignment.align_batch([], None, ALIGN_METADATA, [], "cpu", 0)
+
+
+@pytest.mark.parametrize("feat_extract_norm", ["group", None, "custom"])
+def test_huggingface_batch_falls_back_for_unvalidated_norms(
+    monkeypatch, feat_extract_norm
+):
+    model = SimpleNamespace(config=SimpleNamespace(feat_extract_norm=feat_extract_norm))
+    calls = []
+
+    def compute_serial(waveform, model, model_type, device):
+        calls.append(waveform.shape)
+        return torch.zeros(waveform.shape[-1], 2)
+
+    monkeypatch.setattr(alignment, "_compute_emission", compute_serial)
+    emissions = alignment._compute_emission_batch(
+        [torch.zeros(1, 399), torch.zeros(800)], model, "huggingface", "cpu"
+    )
+
+    assert calls == [torch.Size([1, 399]), torch.Size([1, 800])]
+    assert [emission.shape for emission in emissions] == [(399, 2), (800, 2)]

--- a/tests/test_word_timestamp_interpolation.py
+++ b/tests/test_word_timestamp_interpolation.py
@@ -1,11 +1,13 @@
 """Test that align() produces word-level timestamps for unalignable characters."""
 
-import numpy as np
-import pandas as pd
-import torch
 from unittest.mock import MagicMock
 
-from whisperx.alignment import align
+import numpy as np
+import pytest
+import torch
+
+from whisperx.alignment import _get_aligned_subsegments, _get_sentence_words, align
+from whisperx.schema import CharAlignmentArrays
 from whisperx.utils import interpolate_nans
 
 
@@ -49,6 +51,47 @@ def _make_emission(num_frames, dictionary, transcript_chars, blank_id=0):
                 emission[t, blank_id] = -3.0  # suppress blank
 
     return emission
+
+
+def test_sentence_words_are_aggregated_from_character_arrays():
+    alignments = CharAlignmentArrays(
+        chars=list("hi all"),
+        starts=np.array([0.0, 0.1, np.nan, 0.3, 0.4, 0.5]),
+        ends=np.array([0.1, 0.2, np.nan, 0.4, 0.5, 0.6]),
+        scores=np.array([0.9, 0.7, np.nan, 0.6, 0.8, 1.0]),
+        word_ids=np.array([0, 0, 0, 1, 1, 1]),
+    )
+
+    assert _get_sentence_words(alignments, 0, len(alignments.chars)) == [
+        {"word": "hi", "start": 0.0, "end": 0.2, "score": 0.8},
+        {"word": "all", "start": 0.3, "end": 0.6, "score": 0.8},
+    ]
+
+
+def test_aligned_subsegments_include_optional_metadata():
+    alignments = CharAlignmentArrays(
+        chars=list("你好吗"),
+        starts=np.array([0.0, 0.5, 1.0]),
+        ends=np.array([0.5, 1.0, 1.5]),
+        scores=np.array([0.9, 0.7, 0.8]),
+        word_ids=np.array([0, 1, 2]),
+    )
+
+    segments = _get_aligned_subsegments(
+        alignments,
+        sentence_spans=[(0, 3)],
+        text="你好吗",
+        model_lang="zh",
+        interpolate_method="nearest",
+        return_char_alignments=True,
+        avg_logprob=-0.25,
+    )
+
+    assert segments[0]["text"] == "你好吗"
+    assert (segments[0]["start"], segments[0]["end"]) == (0.0, 1.5)
+    assert segments[0]["avg_logprob"] == -0.25
+    assert [word["word"] for word in segments[0]["words"]] == list("你好吗")
+    assert [char["char"] for char in segments[0]["chars"]] == list("你好吗")
 
 
 class TestAlignWithWildcards:
@@ -174,23 +217,48 @@ class TestAlignWithWildcards:
 class TestInterpolateNans:
     """Unit tests for interpolate_nans()."""
 
-    def test_ignore_preserves_nans(self):
-        x = pd.Series([1.0, np.nan, 3.0, np.nan, 5.0])
-        result = interpolate_nans(x, method="ignore")
-        assert result is x
-        assert result.isna().sum() == 2
+    @pytest.mark.parametrize(
+        ("method", "expected"),
+        [
+            ("nearest", [1.0, 1.0, 1.0, 4.0, 4.0, 4.0]),
+            ("linear", [1.0, 1.0, 2.0, 3.0, 4.0, 4.0]),
+            ("ignore", [np.nan, 1.0, np.nan, np.nan, 4.0, np.nan]),
+        ],
+    )
+    def test_interpolation_methods(self, method, expected):
+        actual = interpolate_nans([np.nan, 1.0, np.nan, np.nan, 4.0, np.nan], method)
+        np.testing.assert_equal(actual, expected)
 
-    def test_nearest_fills_nans(self):
-        x = pd.Series([1.0, np.nan, 3.0, np.nan, 5.0])
-        result = interpolate_nans(x, method="nearest")
-        assert result.notna().all()
+    @pytest.mark.parametrize(
+        ("values", "expected"),
+        [
+            ([np.nan, np.nan], [np.nan, np.nan]),
+            ([np.nan, 2.0, np.nan], [2.0, 2.0, 2.0]),
+        ],
+    )
+    def test_sparse_known_values(self, values, expected):
+        np.testing.assert_equal(interpolate_nans(values), expected)
+
+    @pytest.mark.parametrize("method", ["linear", "nearest"])
+    def test_complete_input_is_unchanged(self, method):
+        values = [1.0, 2.0, 3.0]
+        np.testing.assert_equal(interpolate_nans(values, method), values)
+
+    def test_does_not_mutate_input(self):
+        values = np.array([1.0, np.nan, 3.0])
+        interpolate_nans(values)
+        np.testing.assert_equal(values, [1.0, np.nan, 3.0])
+
+    def test_rejects_unknown_method(self):
+        with pytest.raises(ValueError, match="Invalid interpolation method"):
+            interpolate_nans([np.nan, np.nan], "cubic")
 
     def test_ignore_word_assignment_integration(self):
         """Simulate the word-timestamp assignment logic from alignment.py:365-376.
 
         With wildcard CTC, this path is rarely reached in practice, but it's
         the code that "ignore" is designed to affect. This test proves the
-        pieces fit together: interpolate_nans preserves NaN, and the pd.notna
+        pieces fit together: interpolate_nans preserves NaN, and the NaN
         guard prevents timestamp assignment to unaligned words.
         """
         sentence_words = [
@@ -198,17 +266,17 @@ class TestInterpolateNans:
             {"word": "99"},  # simulates a word with no CTC timestamps
             {"word": "cats", "start": 0.6, "end": 0.9},
         ]
-        _starts = pd.Series([0.1, np.nan, 0.6])
-        _ends = pd.Series([0.3, np.nan, 0.9])
+        _starts = np.array([0.1, np.nan, 0.6])
+        _ends = np.array([0.3, np.nan, 0.9])
 
         # With "ignore": NaNs preserved, unaligned word stays without timestamps
         _starts_ign = interpolate_nans(_starts, method="ignore")
         _ends_ign = interpolate_nans(_ends, method="ignore")
         for i, w in enumerate(sentence_words):
-            if "start" not in w and pd.notna(_starts_ign.iloc[i]):
-                w["start"] = _starts_ign.iloc[i]
-            if "end" not in w and pd.notna(_ends_ign.iloc[i]):
-                w["end"] = _ends_ign.iloc[i]
+            if "start" not in w and not np.isnan(_starts_ign[i]):
+                w["start"] = _starts_ign[i]
+            if "end" not in w and not np.isnan(_ends_ign[i]):
+                w["end"] = _ends_ign[i]
 
         assert "start" not in sentence_words[1], "'99' should not get start with ignore"
         assert "end" not in sentence_words[1], "'99' should not get end with ignore"
@@ -222,10 +290,10 @@ class TestInterpolateNans:
         _starts_nr = interpolate_nans(_starts.copy(), method="nearest")
         _ends_nr = interpolate_nans(_ends.copy(), method="nearest")
         for i, w in enumerate(sentence_words_nearest):
-            if "start" not in w and pd.notna(_starts_nr.iloc[i]):
-                w["start"] = _starts_nr.iloc[i]
-            if "end" not in w and pd.notna(_ends_nr.iloc[i]):
-                w["end"] = _ends_nr.iloc[i]
+            if "start" not in w and not np.isnan(_starts_nr[i]):
+                w["start"] = _starts_nr[i]
+            if "end" not in w and not np.isnan(_ends_nr[i]):
+                w["end"] = _ends_nr[i]
 
         assert "start" in sentence_words_nearest[1], "'99' should get start with nearest"
         assert "end" in sentence_words_nearest[1], "'99' should get end with nearest"

--- a/whisperx/__init__.py
+++ b/whisperx/__init__.py
@@ -16,6 +16,11 @@ def align(*args, **kwargs):
     return alignment.align(*args, **kwargs)
 
 
+def align_batch(*args, **kwargs):
+    alignment = _lazy_import("alignment")
+    return alignment.align_batch(*args, **kwargs)
+
+
 def load_model(*args, **kwargs):
     asr = _lazy_import("asr")
     return asr.load_model(*args, **kwargs)

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -17,7 +17,6 @@ from whisperx.schema import (
     CharAlignmentArrays,
     SingleSegment,
     SingleAlignedSegment,
-    SingleWordSegment,
     SegmentData,
     ProgressCallback,
 )
@@ -234,6 +233,264 @@ def load_align_model(language_code: str, device: str, model_name: Optional[str] 
     return align_model, align_metadata
 
 
+def _prepare_audio(audio: Union[str, np.ndarray, torch.Tensor]) -> torch.Tensor:
+    if not torch.is_tensor(audio):
+        if isinstance(audio, str):
+            audio = load_audio(audio)
+        audio = torch.from_numpy(audio)
+    if audio.ndim == 1:
+        audio = audio.unsqueeze(0)
+    return audio
+
+
+def _prepare_alignment(
+    transcript: Iterable[SingleSegment],
+    model_lang: str,
+    model_dictionary: dict,
+) -> dict[int, SegmentData]:
+    punkt_lang = PUNKT_LANGUAGES.get(model_lang, "english")
+    try:
+        sentence_splitter = nltk_load(f"tokenizers/punkt_tab/{punkt_lang}.pickle")
+    except LookupError as error:
+        logger.info("Downloading NLTK punkt_tab data for sentence splitting...")
+        if not nltk.download("punkt_tab", quiet=True):
+            raise RuntimeError(
+                "Failed to download NLTK 'punkt_tab' data, which is required for sentence splitting. "
+                "Check your network connection, or install it manually with: python -m nltk.downloader punkt_tab"
+            ) from error
+        sentence_splitter = nltk_load(f"tokenizers/punkt_tab/{punkt_lang}.pickle")
+
+    segment_data = {}
+    for segment_index, segment in enumerate(transcript):
+        text = segment["text"]
+        num_leading = len(text) - len(text.lstrip())
+        num_trailing = len(text) - len(text.rstrip())
+        per_word = text if model_lang in LANGUAGES_WITHOUT_SPACES else text.split(" ")
+
+        clean_char, clean_cdx = [], []
+        for char_index, char in enumerate(text):
+            normalized = char.lower()
+            if model_lang not in LANGUAGES_WITHOUT_SPACES:
+                normalized = normalized.replace(" ", "|")
+            if char_index < num_leading or char_index > len(text) - num_trailing - 1:
+                continue
+            if normalized in model_dictionary or normalized not in (" ", "|"):
+                clean_char.append(normalized)
+                clean_cdx.append(char_index)
+
+        segment_data[segment_index] = {
+            "clean_char": clean_char,
+            "clean_cdx": clean_cdx,
+            "clean_wdx": list(range(len(per_word))),
+            "sentence_spans": list(sentence_splitter.span_tokenize(text)),
+        }
+    return segment_data
+
+
+def _compute_emission(
+    waveform: torch.Tensor,
+    model: torch.nn.Module,
+    model_type: str,
+    device: str,
+) -> torch.Tensor:
+    if waveform.shape[-1] < 400:
+        lengths = torch.as_tensor([waveform.shape[-1]], device=device)
+        waveform = torch.nn.functional.pad(waveform, (0, 400 - waveform.shape[-1]))
+    else:
+        lengths = None
+
+    with torch.inference_mode():
+        if model_type == "torchaudio":
+            emissions, _ = model(waveform.to(device), lengths=lengths)
+        elif model_type == "huggingface":
+            emissions = model(waveform.to(device)).logits
+        else:
+            raise NotImplementedError(f"Align model of type {model_type} not supported.")
+        return torch.log_softmax(emissions, dim=-1)[0].cpu().detach()
+
+
+def _compute_emission_batch(
+    waveforms: list[torch.Tensor],
+    model: torch.nn.Module,
+    model_type: str,
+    device: str,
+) -> list[torch.Tensor]:
+    if not waveforms:
+        return []
+
+    flattened = []
+    for waveform in waveforms:
+        if waveform.ndim == 2 and waveform.shape[0] == 1:
+            waveform = waveform.squeeze(0)
+        elif waveform.ndim != 1:
+            raise ValueError(
+                "Each waveform must have shape [time] or [1, time], "
+                f"but found {list(waveform.shape)}."
+            )
+        flattened.append(waveform)
+
+    with torch.inference_mode():
+        if model_type == "torchaudio":
+            # Padding before GroupNorm changes shorter inputs. Run the only
+            # GroupNorm convolution per item, then batch the remaining model.
+            first_block = model.feature_extractor.conv_layers[0]
+            sequences = []
+            for waveform in flattened:
+                if waveform.shape[-1] < 400:
+                    waveform = torch.nn.functional.pad(
+                        waveform, (0, 400 - waveform.shape[-1])
+                    )
+                features, _ = first_block(
+                    waveform.unsqueeze(0).unsqueeze(0).to(device), length=None
+                )
+                sequences.append(features.squeeze(0).transpose(0, 1))
+
+            output_lengths = torch.as_tensor(
+                [sequence.shape[0] for sequence in sequences],
+                dtype=torch.long,
+                device=device,
+            )
+            features = torch.nn.utils.rnn.pad_sequence(
+                sequences, batch_first=True
+            ).transpose(1, 2)
+            for conv_layer in model.feature_extractor.conv_layers[1:]:
+                features, output_lengths = conv_layer(features, output_lengths)
+            emissions = model.encoder(features.transpose(1, 2), lengths=output_lengths)
+            if model.aux is not None:
+                emissions = model.aux(emissions)
+        elif model_type == "huggingface":
+            # Only LayerNorm models are invariant to padded batch inputs.
+            if getattr(model.config, "feat_extract_norm", None) != "layer":
+                return [
+                    _compute_emission(waveform.unsqueeze(0), model, model_type, device)
+                    for waveform in flattened
+                ]
+            lengths = torch.as_tensor(
+                [waveform.shape[-1] for waveform in flattened],
+                dtype=torch.long,
+                device=device,
+            )
+            waveform_batch = torch.nn.utils.rnn.pad_sequence(
+                flattened, batch_first=True
+            )
+            if waveform_batch.shape[-1] < 400:
+                waveform_batch = torch.nn.functional.pad(
+                    waveform_batch, (0, 400 - waveform_batch.shape[-1])
+                )
+            waveform_batch = waveform_batch.to(device)
+            effective_lengths = lengths.clamp_min(400)
+            attention_mask = (
+                torch.arange(waveform_batch.shape[-1], device=device).unsqueeze(0)
+                < effective_lengths.unsqueeze(1)
+            ).long()
+            emissions = model(waveform_batch, attention_mask=attention_mask).logits
+            output_lengths = model._get_feat_extract_output_lengths(effective_lengths)
+        else:
+            raise NotImplementedError(f"Align model of type {model_type} not supported.")
+        emissions = torch.log_softmax(emissions, dim=-1).cpu().detach()
+
+    return [
+        emission[:output_length]
+        for emission, output_length in zip(
+            emissions, output_lengths.cpu().tolist(), strict=True
+        )
+    ]
+
+
+def _unaligned_segment(
+    segment: SingleSegment,
+    return_char_alignments: bool,
+) -> SingleAlignedSegment:
+    result: SingleAlignedSegment = {
+        "start": segment["start"],
+        "end": segment["end"],
+        "text": segment["text"],
+        "words": [],
+        "chars": [] if return_char_alignments else None,
+    }
+    if "avg_logprob" in segment:
+        result["avg_logprob"] = segment["avg_logprob"]
+    return result
+
+
+def _finish_alignment_segment(
+    segment: SingleSegment,
+    data: SegmentData,
+    waveform: torch.Tensor,
+    emission: torch.Tensor,
+    model_dictionary: dict,
+    model_lang: str,
+    interpolate_method: str,
+    return_char_alignments: bool,
+) -> Optional[list[SingleAlignedSegment]]:
+    text = segment["text"]
+    text_clean = "".join(data["clean_char"])
+    blank_id = next(
+        (code for char, code in model_dictionary.items() if char in ("[pad]", "<pad>")),
+        0,
+    )
+
+    has_wildcard = any(char not in model_dictionary for char in text_clean)
+    if has_wildcard:
+        non_blank_mask = torch.ones(emission.size(1), dtype=torch.bool)
+        non_blank_mask[blank_id] = False
+        wildcard = emission[:, non_blank_mask].max(dim=1).values
+        emission = torch.cat([emission, wildcard.unsqueeze(1)], dim=1)
+        tokens = [model_dictionary.get(char, emission.size(1) - 1) for char in text_clean]
+    else:
+        tokens = [model_dictionary[char] for char in text_clean]
+
+    trellis = get_trellis(emission, tokens, blank_id)
+    path = backtrack(trellis, emission, tokens, blank_id)
+    if path is None:
+        return None
+
+    char_segments = merge_repeats(path, text_clean)
+    ratio = (
+        (segment["end"] - segment["start"])
+        * waveform.size(0)
+        / (trellis.size(0) - 1)
+    )
+    chars = list(text)
+    starts = np.full(len(chars), np.nan, dtype=np.float64)
+    ends = np.full(len(chars), np.nan, dtype=np.float64)
+    scores = np.full(len(chars), np.nan, dtype=np.float64)
+    word_ids = np.empty(len(chars), dtype=np.int32)
+    for char_index, char_segment in zip(data["clean_cdx"], char_segments, strict=True):
+        starts[char_index] = round(char_segment.start * ratio + segment["start"], 3)
+        ends[char_index] = round(char_segment.end * ratio + segment["start"], 3)
+        scores[char_index] = round(char_segment.score, 3)
+
+    word_index = 0
+    for char_index in range(len(chars)):
+        word_ids[char_index] = word_index
+        if model_lang in LANGUAGES_WITHOUT_SPACES:
+            word_index += 1
+        elif char_index == len(chars) - 1 or chars[char_index + 1] == " ":
+            word_index += 1
+
+    return _get_aligned_subsegments(
+        CharAlignmentArrays(chars, starts, ends, scores, word_ids),
+        data["sentence_spans"],
+        text,
+        model_lang,
+        interpolate_method,
+        return_char_alignments,
+        segment.get("avg_logprob"),
+    )
+
+
+def _assemble_alignment_result(
+    aligned_segments: list[SingleAlignedSegment],
+) -> AlignedTranscriptionResult:
+    return {
+        "segments": aligned_segments,
+        "word_segments": [
+            word for segment in aligned_segments for word in segment["words"]
+        ],
+    }
+
+
 def align(
     transcript: Iterable[SingleSegment],
     model: torch.nn.Module,
@@ -363,105 +620,153 @@ def align(
             aligned_segments.append(aligned_seg)
             continue
 
-        text_clean = "".join(segment_data[sdx]["clean_char"])
-
         f1 = int(t1 * SAMPLE_RATE)
         f2 = int(t2 * SAMPLE_RATE)
 
-        # TODO: Probably can get some speedup gain with batched inference here
         waveform_segment = audio[:, f1:f2]
-        # Handle the minimum input length for wav2vec2 models
-        if waveform_segment.shape[-1] < 400:
-            lengths = torch.as_tensor([waveform_segment.shape[-1]]).to(device)
-            waveform_segment = torch.nn.functional.pad(
-                waveform_segment, (0, 400 - waveform_segment.shape[-1])
-            )
-        else:
-            lengths = None
-
-        with torch.inference_mode():
-            if model_type == "torchaudio":
-                emissions, _ = model(waveform_segment.to(device), lengths=lengths)
-            elif model_type == "huggingface":
-                emissions = model(waveform_segment.to(device)).logits
-            else:
-                raise NotImplementedError(f"Align model of type {model_type} not supported.")
-            emissions = torch.log_softmax(emissions, dim=-1)
-
-        emission = emissions[0].cpu().detach()
-
-        blank_id = 0
-        for char, code in model_dictionary.items():
-            if char == '[pad]' or char == '<pad>':
-                blank_id = code
-
-        # Build tokens, mapping unknown chars to a wildcard column
-        has_wildcard = any(c not in model_dictionary for c in text_clean)
-        if has_wildcard:
-            # Extend emission with a wildcard column: max non-blank score per frame
-            non_blank_mask = torch.ones(emission.size(1), dtype=torch.bool)
-            non_blank_mask[blank_id] = False
-            wildcard_col = emission[:, non_blank_mask].max(dim=1).values
-            emission = torch.cat([emission, wildcard_col.unsqueeze(1)], dim=1)
-            wildcard_id = emission.size(1) - 1
-            tokens = [model_dictionary.get(c, wildcard_id) for c in text_clean]
-        else:
-            tokens = [model_dictionary[c] for c in text_clean]
-
-        trellis = get_trellis(emission, tokens, blank_id)
-        path = backtrack(trellis, emission, tokens, blank_id)
-
-        if path is None:
-            logger.warning(f'Failed to align segment ("{segment["text"]}"): backtrack failed, resorting to original')
-            aligned_segments.append(aligned_seg)
-            continue
-
-        char_segments = merge_repeats(path, text_clean)
-
-        duration = t2 - t1
-        ratio = duration * waveform_segment.size(0) / (trellis.size(0) - 1)
-
-        # assign timestamps to aligned characters
-        chars = list(text)
-        starts = np.full(len(chars), np.nan, dtype=np.float64)
-        ends = np.full(len(chars), np.nan, dtype=np.float64)
-        scores = np.full(len(chars), np.nan, dtype=np.float64)
-        word_ids = np.empty(len(chars), dtype=np.int32)
-
-        for cdx, char_seg in zip(segment_data[sdx]["clean_cdx"], char_segments, strict=True):
-            starts[cdx] = round(char_seg.start * ratio + t1, 3)
-            ends[cdx] = round(char_seg.end * ratio + t1, 3)
-            scores[cdx] = round(char_seg.score, 3)
-
-        word_idx = 0
-        for cdx in range(len(chars)):
-            word_ids[cdx] = word_idx
-            # increment word_idx, nltk word tokenization would probably be more robust here, but us space for now...
-            if model_lang in LANGUAGES_WITHOUT_SPACES:
-                word_idx += 1
-            elif cdx == len(chars) - 1 or chars[cdx + 1] == " ":
-                word_idx += 1
-
-        aligned_subsegments = _get_aligned_subsegments(
-            CharAlignmentArrays(chars, starts, ends, scores, word_ids),
-            segment_data[sdx]["sentence_spans"],
-            text,
+        emission = _compute_emission(waveform_segment, model, model_type, device)
+        aligned_subsegments = _finish_alignment_segment(
+            segment,
+            segment_data[sdx],
+            waveform_segment,
+            emission,
+            model_dictionary,
             model_lang,
             interpolate_method,
             return_char_alignments,
-            avg_logprob,
         )
+        if aligned_subsegments is None:
+            logger.warning(f'Failed to align segment ("{segment["text"]}"): backtrack failed, resorting to original')
+            aligned_segments.append(aligned_seg)
+            continue
         if progress_callback is not None:
             progress_callback(((sdx + 1) / total_segments) * 100)
 
         aligned_segments += aligned_subsegments
 
-    # create word_segments list
-    word_segments: List[SingleWordSegment] = []
-    for segment in aligned_segments:
-        word_segments += segment["words"]
+    return _assemble_alignment_result(aligned_segments)
 
-    return {"segments": aligned_segments, "word_segments": word_segments}
+
+def align_batch(
+    transcripts: list[list[SingleSegment]],
+    model: torch.nn.Module,
+    align_model_metadata: dict,
+    audio: list[Union[str, np.ndarray, torch.Tensor]],
+    device: str,
+    batch_size: int,
+    interpolate_method: str = "nearest",
+    return_char_alignments: bool = False,
+    print_progress: bool = False,
+    combined_progress: bool = False,
+    progress_callback: ProgressCallback = None,
+) -> list[AlignedTranscriptionResult]:
+    """Align multiple audio inputs with duration-sorted model batches."""
+    if len(transcripts) != len(audio):
+        raise ValueError(
+            "transcripts and audio must contain the same number of items, "
+            f"but found {len(transcripts)} transcripts and {len(audio)} audio items."
+        )
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be at least 1, but found {batch_size}.")
+
+    audios = [_prepare_audio(audio_item) for audio_item in audio]
+    model_dictionary = align_model_metadata["dictionary"]
+    model_lang = align_model_metadata["language"]
+    model_type = align_model_metadata["type"]
+    segment_results: list[list[Optional[list[SingleAlignedSegment]]]] = [
+        [None] * len(transcript) for transcript in transcripts
+    ]
+    jobs = []
+    total_segments = sum(len(transcript) for transcript in transcripts)
+    processed_segments = 0
+
+    for audio_index, (transcript, audio_item) in enumerate(
+        zip(transcripts, audios, strict=True)
+    ):
+        max_duration = audio_item.shape[1] / SAMPLE_RATE
+        segment_data = _prepare_alignment(transcript, model_lang, model_dictionary)
+        for segment_index, segment in enumerate(transcript):
+            processed_segments += 1
+            if print_progress and total_segments:
+                base_progress = processed_segments / total_segments * 100
+                percent_complete = (
+                    50 + base_progress / 2 if combined_progress else base_progress
+                )
+                print(f"Progress: {percent_complete:.2f}%...")
+
+            fallback = _unaligned_segment(segment, return_char_alignments)
+            if not segment_data[segment_index]["clean_char"]:
+                logger.warning(
+                    f'Failed to align segment ("{segment["text"]}"): no characters '
+                    "in this segment found in model dictionary, resorting to original"
+                )
+                segment_results[audio_index][segment_index] = [fallback]
+                continue
+            if segment["start"] >= max_duration:
+                logger.warning(
+                    f'Failed to align segment ("{segment["text"]}"): original start '
+                    "time longer than audio duration, skipping"
+                )
+                segment_results[audio_index][segment_index] = [fallback]
+                continue
+
+            first_sample = int(segment["start"] * SAMPLE_RATE)
+            last_sample = int(segment["end"] * SAMPLE_RATE)
+            jobs.append(
+                {
+                    "audio_index": audio_index,
+                    "segment_index": segment_index,
+                    "segment": segment,
+                    "data": segment_data[segment_index],
+                    "waveform": audio_item[:, first_sample:last_sample],
+                    "fallback": fallback,
+                }
+            )
+
+    jobs.sort(key=lambda job: job["waveform"].shape[-1])
+    completed_segments = 0
+    for batch_start in range(0, len(jobs), batch_size):
+        batch = jobs[batch_start:batch_start + batch_size]
+        emissions = _compute_emission_batch(
+            [job["waveform"] for job in batch], model, model_type, device
+        )
+        if len(emissions) != len(batch):
+            raise RuntimeError(
+                "Alignment model returned an unexpected number of emissions: "
+                f"expected {len(batch)}, found {len(emissions)}."
+            )
+        for job, emission in zip(batch, emissions, strict=True):
+            aligned = _finish_alignment_segment(
+                job["segment"],
+                job["data"],
+                job["waveform"],
+                emission,
+                model_dictionary,
+                model_lang,
+                interpolate_method,
+                return_char_alignments,
+            )
+            if aligned is None:
+                logger.warning(
+                    f'Failed to align segment ("{job["segment"]["text"]}"): '
+                    "backtrack failed, resorting to original"
+                )
+                aligned = [job["fallback"]]
+            segment_results[job["audio_index"]][job["segment_index"]] = aligned
+            completed_segments += 1
+            if progress_callback is not None and total_segments:
+                progress_callback(completed_segments / total_segments * 100)
+
+    results = []
+    for audio_results in segment_results:
+        aligned_segments = []
+        for aligned in audio_results:
+            if aligned is None:
+                raise RuntimeError("Internal error: alignment segment was not processed.")
+            aligned_segments.extend(aligned)
+        results.append(_assemble_alignment_result(aligned_segments))
+    return results
+
 
 """
 source: https://pytorch.org/tutorials/intermediate/forced_alignment_with_torchaudio_tutorial.html

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -6,15 +6,15 @@ from dataclasses import dataclass
 from typing import Iterable, Optional, Union, List
 
 import numpy as np
-import pandas as pd
 import torch
 import torchaudio
 from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
 
 from whisperx.audio import SAMPLE_RATE, load_audio
-from whisperx.utils import interpolate_nans, PUNKT_LANGUAGES
+from whisperx.utils import PUNKT_LANGUAGES, interpolate_nans
 from whisperx.schema import (
     AlignedTranscriptionResult,
+    CharAlignmentArrays,
     SingleSegment,
     SingleAlignedSegment,
     SingleWordSegment,
@@ -75,6 +75,126 @@ DEFAULT_ALIGN_MODELS_HF = {
     "sv": "KBLab/wav2vec2-large-voxrex-swedish",
     "id": "cahya/wav2vec2-large-xlsr-indonesian",
 }
+
+
+def _get_sentence_words(
+    alignments: CharAlignmentArrays,
+    start: int,
+    stop: int,
+) -> list[dict]:
+    sentence_words = []
+    word_start = start
+    while word_start < stop:
+        word_id = alignments.word_ids[word_start]
+        word_stop = word_start + 1
+        while word_stop < stop and alignments.word_ids[word_stop] == word_id:
+            word_stop += 1
+
+        word_text = "".join(alignments.chars[word_start:word_stop]).strip()
+        if word_text:
+            aligned_indices = [
+                index
+                for index in range(word_start, word_stop)
+                if alignments.chars[index] != " "
+            ]
+            word_start_time = np.nanmin(alignments.starts[aligned_indices])
+            word_end_time = np.nanmax(alignments.ends[aligned_indices])
+            word_score = round(np.nanmean(alignments.scores[aligned_indices]), 3)
+
+            word_segment = {"word": word_text}
+            if not np.isnan(word_start_time):
+                word_segment["start"] = word_start_time
+            if not np.isnan(word_end_time):
+                word_segment["end"] = word_end_time
+            if not np.isnan(word_score):
+                word_segment["score"] = word_score
+            sentence_words.append(word_segment)
+        word_start = word_stop
+    return sentence_words
+
+
+def _get_aligned_subsegments(
+    alignments: CharAlignmentArrays,
+    sentence_spans: list[tuple[int, int]],
+    text: str,
+    model_lang: str,
+    interpolate_method: str,
+    return_char_alignments: bool,
+    avg_logprob: Optional[float],
+) -> list[SingleAlignedSegment]:
+    aligned_subsegments = []
+    for sstart, send in sentence_spans:
+        # Preserve the existing inclusive character selection at `send`,
+        # while sentence text itself uses Punkt's exclusive end offset.
+        char_stop = min(send + 1, len(alignments.chars))
+        sentence_start = np.nanmin(alignments.starts[sstart:char_stop])
+        non_space_indices = [
+            index
+            for index in range(sstart, char_stop)
+            if alignments.chars[index] != " "
+        ]
+        sentence_end = np.nanmax(alignments.ends[non_space_indices])
+        sentence_words = _get_sentence_words(alignments, sstart, char_stop)
+
+        if sentence_words:
+            word_starts = [word.get("start", np.nan) for word in sentence_words]
+            word_ends = [word.get("end", np.nan) for word in sentence_words]
+            if np.isnan(word_starts).any() and not np.isnan(word_starts).all():
+                word_starts = interpolate_nans(word_starts, interpolate_method)
+                word_ends = interpolate_nans(word_ends, interpolate_method)
+                for index, word in enumerate(sentence_words):
+                    if "start" not in word and not np.isnan(word_starts[index]):
+                        word["start"] = float(word_starts[index])
+                    if "end" not in word and not np.isnan(word_ends[index]):
+                        word["end"] = float(word_ends[index])
+
+        subsegment: SingleAlignedSegment = {
+            "text": text[sstart:send],
+            "start": sentence_start,
+            "end": sentence_end,
+            "words": sentence_words,
+        }
+        if avg_logprob is not None:
+            subsegment["avg_logprob"] = avg_logprob
+        if return_char_alignments:
+            sentence_chars = []
+            for index in range(sstart, char_stop):
+                char = {"char": alignments.chars[index]}
+                if not np.isnan(alignments.starts[index]):
+                    char["start"] = float(alignments.starts[index])
+                if not np.isnan(alignments.ends[index]):
+                    char["end"] = float(alignments.ends[index])
+                if not np.isnan(alignments.scores[index]):
+                    char["score"] = float(alignments.scores[index])
+                sentence_chars.append(char)
+            subsegment["chars"] = sentence_chars
+        aligned_subsegments.append(subsegment)
+
+    starts = interpolate_nans(
+        [segment["start"] for segment in aligned_subsegments],
+        interpolate_method,
+    )
+    ends = interpolate_nans(
+        [segment["end"] for segment in aligned_subsegments],
+        interpolate_method,
+    )
+
+    separator = "" if model_lang in LANGUAGES_WITHOUT_SPACES else " "
+    grouped: dict[tuple[float, float], SingleAlignedSegment] = {}
+    for segment, start, end in zip(aligned_subsegments, starts, ends, strict=True):
+        if np.isnan(start) or np.isnan(end):
+            continue
+        key = (float(start), float(end))
+        if key not in grouped:
+            segment["start"], segment["end"] = key
+            grouped[key] = segment
+            continue
+        grouped_segment = grouped[key]
+        grouped_segment["text"] += separator + segment["text"]
+        grouped_segment["words"].extend(segment["words"])
+        if return_char_alignments:
+            grouped_segment["chars"].extend(segment["chars"])
+    return [grouped[key] for key in sorted(grouped)]
 
 
 def load_align_model(language_code: str, device: str, model_name: Optional[str] = None, model_dir=None, model_cache_only: bool = False):
@@ -302,115 +422,35 @@ def align(
         ratio = duration * waveform_segment.size(0) / (trellis.size(0) - 1)
 
         # assign timestamps to aligned characters
-        char_segments_arr = []
+        chars = list(text)
+        starts = np.full(len(chars), np.nan, dtype=np.float64)
+        ends = np.full(len(chars), np.nan, dtype=np.float64)
+        scores = np.full(len(chars), np.nan, dtype=np.float64)
+        word_ids = np.empty(len(chars), dtype=np.int32)
+
+        for cdx, char_seg in zip(segment_data[sdx]["clean_cdx"], char_segments, strict=True):
+            starts[cdx] = round(char_seg.start * ratio + t1, 3)
+            ends[cdx] = round(char_seg.end * ratio + t1, 3)
+            scores[cdx] = round(char_seg.score, 3)
+
         word_idx = 0
-        for cdx, char in enumerate(text):
-            start, end, score = None, None, None
-            if cdx in segment_data[sdx]["clean_cdx"]:
-                char_seg = char_segments[segment_data[sdx]["clean_cdx"].index(cdx)]
-                start = round(char_seg.start * ratio + t1, 3)
-                end = round(char_seg.end * ratio + t1, 3)
-                score = round(char_seg.score, 3)
-
-            char_segments_arr.append(
-                {
-                    "char": char,
-                    "start": start,
-                    "end": end,
-                    "score": score,
-                    "word-idx": word_idx,
-                }
-            )
-
+        for cdx in range(len(chars)):
+            word_ids[cdx] = word_idx
             # increment word_idx, nltk word tokenization would probably be more robust here, but us space for now...
             if model_lang in LANGUAGES_WITHOUT_SPACES:
                 word_idx += 1
-            elif cdx == len(text) - 1 or text[cdx+1] == " ":
+            elif cdx == len(chars) - 1 or chars[cdx + 1] == " ":
                 word_idx += 1
 
-        char_segments_arr = pd.DataFrame(char_segments_arr)
-
-        aligned_subsegments = []
-        # assign sentence_idx to each character index
-        char_segments_arr["sentence-idx"] = None
-        for sdx2, (sstart, send) in enumerate(segment_data[sdx]["sentence_spans"]):
-            curr_chars = char_segments_arr.loc[(char_segments_arr.index >= sstart) & (char_segments_arr.index <= send)]
-            char_segments_arr.loc[(char_segments_arr.index >= sstart) & (char_segments_arr.index <= send), "sentence-idx"] = sdx2
-
-            sentence_text = text[sstart:send]
-            sentence_start = curr_chars["start"].min()
-            end_chars = curr_chars[curr_chars["char"] != ' ']
-            sentence_end = end_chars["end"].max()
-            sentence_words = []
-
-            for word_idx in curr_chars["word-idx"].unique():
-                word_chars = curr_chars.loc[curr_chars["word-idx"] == word_idx]
-                word_text = "".join(word_chars["char"].tolist()).strip()
-                if len(word_text) == 0:
-                    continue
-
-                # dont use space character for alignment
-                word_chars = word_chars[word_chars["char"] != " "]
-
-                word_start = word_chars["start"].min()
-                word_end = word_chars["end"].max()
-                word_score = round(word_chars["score"].mean(), 3)
-
-                # -1 indicates unalignable
-                word_segment = {"word": word_text}
-
-                if not np.isnan(word_start):
-                    word_segment["start"] = word_start
-                if not np.isnan(word_end):
-                    word_segment["end"] = word_end
-                if not np.isnan(word_score):
-                    word_segment["score"] = word_score
-
-                sentence_words.append(word_segment)
-
-            # Interpolate timestamps for words with no alignable characters
-            if sentence_words:
-                _starts = pd.Series([w.get("start", np.nan) for w in sentence_words])
-                _ends = pd.Series([w.get("end", np.nan) for w in sentence_words])
-                if _starts.isna().any() and _starts.notna().any():
-                    _starts = interpolate_nans(_starts, method=interpolate_method)
-                    _ends = interpolate_nans(_ends, method=interpolate_method)
-                    for i, w in enumerate(sentence_words):
-                        if "start" not in w and pd.notna(_starts.iloc[i]):
-                            w["start"] = _starts.iloc[i]
-                        if "end" not in w and pd.notna(_ends.iloc[i]):
-                            w["end"] = _ends.iloc[i]
-
-            subsegment = {
-                "text": sentence_text,
-                "start": sentence_start,
-                "end": sentence_end,
-                "words": sentence_words,
-            }
-            if avg_logprob is not None:
-                subsegment["avg_logprob"] = avg_logprob
-            aligned_subsegments.append(subsegment)
-
-            if return_char_alignments:
-                curr_chars = curr_chars[["char", "start", "end", "score"]]
-                curr_chars.fillna(-1, inplace=True)
-                curr_chars = curr_chars.to_dict("records")
-                curr_chars = [{key: val for key, val in char.items() if val != -1} for char in curr_chars]
-                aligned_subsegments[-1]["chars"] = curr_chars
-
-        aligned_subsegments = pd.DataFrame(aligned_subsegments)
-        aligned_subsegments["start"] = interpolate_nans(aligned_subsegments["start"], method=interpolate_method)
-        aligned_subsegments["end"] = interpolate_nans(aligned_subsegments["end"], method=interpolate_method)
-        # concatenate sentences with same timestamps
-        agg_dict = {"text": " ".join, "words": "sum"}
-        if model_lang in LANGUAGES_WITHOUT_SPACES:
-            agg_dict["text"] = "".join
-        if return_char_alignments:
-            agg_dict["chars"] = "sum"
-        if avg_logprob is not None:
-            agg_dict["avg_logprob"] = "first"
-        aligned_subsegments= aligned_subsegments.groupby(["start", "end"], as_index=False).agg(agg_dict)
-        aligned_subsegments = aligned_subsegments.to_dict('records')
+        aligned_subsegments = _get_aligned_subsegments(
+            CharAlignmentArrays(chars, starts, ends, scores, word_ids),
+            segment_data[sdx]["sentence_spans"],
+            text,
+            model_lang,
+            interpolate_method,
+            return_char_alignments,
+            avg_logprob,
+        )
         if progress_callback is not None:
             progress_callback(((sdx + 1) / total_segments) * 100)
 

--- a/whisperx/schema.py
+++ b/whisperx/schema.py
@@ -1,4 +1,6 @@
-from typing import Callable, TypedDict, Optional, List, Tuple
+from typing import Callable, NamedTuple, TypedDict, Optional, List, Tuple
+
+import numpy as np
 
 ProgressCallback = Optional[Callable[[float], None]]
 
@@ -47,6 +49,16 @@ class SegmentData(TypedDict):
     clean_cdx: List[int]   # Original indices of cleaned characters
     clean_wdx: List[int]   # Indices of words containing valid characters
     sentence_spans: List[Tuple[int, int]]  # Start and end indices of sentences
+
+
+class CharAlignmentArrays(NamedTuple):
+    """Columnar character alignment data indexed by transcript position."""
+
+    chars: List[str]
+    starts: np.ndarray
+    ends: np.ndarray
+    scores: np.ndarray
+    word_ids: np.ndarray
 
 
 class SingleAlignedSegment(TypedDict):

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -3,7 +3,9 @@ import os
 import re
 import sys
 import zlib
-from typing import Callable, Optional, TextIO
+from typing import Callable, Optional, Sequence, TextIO
+
+import numpy as np
 
 LANGUAGES = {
     "en": "english",
@@ -467,10 +469,34 @@ def get_writer(
         return optional_writers[output_format](output_dir)
     return writers[output_format](output_dir)
 
-def interpolate_nans(x, method='nearest'):
+
+def interpolate_nans(
+    values: Sequence[float] | np.ndarray,
+    method: str = "nearest",
+) -> np.ndarray:
+    """Interpolate missing values in a one-dimensional array."""
+    if method not in {"ignore", "linear", "nearest"}:
+        raise ValueError(f"Invalid interpolation method: {method}")
+
+    result = np.array(values, dtype=np.float64, copy=True)
     if method == "ignore":
-        return x
-    if x.notnull().sum() > 1:
-        return x.interpolate(method=method).ffill().bfill()
-    else:
-        return x.ffill().bfill()
+        return result
+
+    known = np.flatnonzero(~np.isnan(result))
+    if known.size == 0:
+        return result
+    if known.size == 1:
+        result.fill(result[known[0]])
+        return result
+
+    missing = np.flatnonzero(np.isnan(result))
+    if method == "linear":
+        result[missing] = np.interp(missing, known, result[known])
+    elif method == "nearest":
+        right_positions = np.searchsorted(known, missing).clip(max=known.size - 1)
+        left_positions = (right_positions - 1).clip(min=0)
+        left = known[left_positions]
+        right = known[right_positions]
+        nearest = np.where(missing - left <= right - missing, left, right)
+        result[missing] = result[nearest]
+    return result


### PR DESCRIPTION
Batch duration-sorted alignment windows while preserving input order and serial fallbacks for unsupported Hugging Face normalization.

In our full benchmark, the stacked NumPy and batching changes reduced alignment time from 3150s to 2103s (1.50x throughput).

Validation: 27 tests pass with warnings treated as errors.

Depends on #1453. Continues #219.