### PR TITLE
feat: add use_tmp_file option to load_audio for low-memory decoding

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,27 @@
+import wave
+
+import numpy as np
+
+from whisperx.audio import SAMPLE_RATE, load_audio
+
+
+def _write_wav(path, sr=SAMPLE_RATE, seconds=1):
+    # A short mono 16-bit PCM tone, enough to exercise both decode paths.
+    samples = (np.sin(np.linspace(0, 2 * np.pi * 220 * seconds, sr * seconds)) * 10000).astype(np.int16)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sr)
+        w.writeframes(samples.tobytes())
+
+
+def test_load_audio_use_tmp_file_matches_in_memory(tmp_path):
+    wav_path = tmp_path / "fixture.wav"
+    _write_wav(wav_path)
+
+    in_memory = load_audio(str(wav_path))
+    via_tmp_file = load_audio(str(wav_path), use_tmp_file=True)
+
+    # The temp-file path must produce exactly the same waveform as the default in-memory path.
+    assert via_tmp_file.dtype == np.float32
+    assert np.array_equal(in_memory, via_tmp_file)

--- a/whisperx/audio.py
+++ b/whisperx/audio.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import tempfile
 from functools import lru_cache
 from typing import Optional, Union
 
@@ -22,7 +23,7 @@ FRAMES_PER_SECOND = exact_div(SAMPLE_RATE, HOP_LENGTH)  # 10ms per audio frame
 TOKENS_PER_SECOND = exact_div(SAMPLE_RATE, N_SAMPLES_PER_TOKEN)  # 20ms per audio token
 
 
-def load_audio(file: str, sr: int = SAMPLE_RATE) -> np.ndarray:
+def load_audio(file: str, sr: int = SAMPLE_RATE, use_tmp_file: bool = False) -> np.ndarray:
     """
     Open an audio file and read as mono waveform, resampling as necessary
 
@@ -34,35 +35,58 @@ def load_audio(file: str, sr: int = SAMPLE_RATE) -> np.ndarray:
     sr: int
         The sample rate to resample the audio if necessary
 
+    use_tmp_file: bool
+        If True, decode to a temporary file on disk instead of buffering the whole
+        output in memory. This keeps peak memory low for very long audio files.
+
     Returns
     -------
     A NumPy array containing the audio waveform, in float32 dtype.
     """
-    try:
-        # Launches a subprocess to decode audio while down-mixing and resampling as necessary.
-        # Requires the ffmpeg CLI to be installed.
-        cmd = [
-            "ffmpeg",
-            "-nostdin",
-            "-threads",
-            "0",
-            "-i",
-            file,
-            "-f",
-            "s16le",
-            "-ac",
-            "1",
-            "-acodec",
-            "pcm_s16le",
-            "-ar",
-            str(sr),
-            "-",
-        ]
-        out = subprocess.run(cmd, capture_output=True, check=True).stdout
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
+    # Launches a subprocess to decode audio while down-mixing and resampling as necessary.
+    # Requires the ffmpeg CLI to be installed. The output target ("-" for stdout, or a file
+    # path) is appended below depending on use_tmp_file.
+    cmd = [
+        "ffmpeg",
+        "-nostdin",
+        "-threads",
+        "0",
+        "-i",
+        file,
+        "-f",
+        "s16le",
+        "-ac",
+        "1",
+        "-acodec",
+        "pcm_s16le",
+        "-ar",
+        str(sr),
+    ]
 
-    return np.frombuffer(out, np.int16).flatten().astype(np.float32) / 32768.0
+    if use_tmp_file:
+        # Write the decoded audio to a temp file on disk so the full waveform never has to
+        # sit in memory at once. Read it back with np.fromfile, then always clean up.
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".s16le", delete=False)
+        tmp_file.close()
+        try:
+            # -y overwrites the just-created temp file without prompting; otherwise ffmpeg
+            # blocks on a "File already exists, overwrite?" prompt it cannot answer under -nostdin.
+            cmd.extend(["-y", tmp_file.name])
+            subprocess.run(cmd, capture_output=True, check=True)
+            audio = np.fromfile(tmp_file.name, np.int16)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
+        finally:
+            os.remove(tmp_file.name)
+    else:
+        cmd.append("-")
+        try:
+            out = subprocess.run(cmd, capture_output=True, check=True).stdout
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
+        audio = np.frombuffer(out, np.int16)
+
+    return audio.flatten().astype(np.float32) / 32768.0
 
 
 def pad_or_trim(array, length: int = N_SAMPLES, *, axis: int = -1):


### PR DESCRIPTION
Closes #1440.

`load_audio` decodes with ffmpeg and buffers the entire PCM stream in memory (`subprocess.run(..., capture_output=True).stdout`). For very long inputs this peaks high (a 10-hour mono 16 kHz file is ~1.15 GB), which can exhaust memory.

This adds an opt-in `use_tmp_file: bool = False` parameter. When enabled, ffmpeg writes the decoded audio to a temporary file and it is read back with `np.fromfile`, so the full waveform never sits in memory at once. The temp file is always removed in a `finally`, and `-y` is passed so ffmpeg overwrites the pre-created temp file without prompting under `-nostdin`.

Default behavior is unchanged: `use_tmp_file=False` uses the existing stdout path.

## Testing
Adds `tests/test_audio.py::test_load_audio_use_tmp_file_matches_in_memory`, which writes a short WAV and asserts both decode paths return identical `float32` waveforms. The full suite (`uv run pytest tests/ -v`) passes locally on Python 3.10 (13 passed).