### PR TITLE
fix(cli): read the Hugging Face token from HF_TOKEN (#1457)

### DIFF
--- a/whisperx/__main__.py
+++ b/whisperx/__main__.py
@@ -74,7 +74,7 @@ def cli():
 
     parser.add_argument("--threads", type=optional_int, default=0, help="number of threads used by torch for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS")
 
-    parser.add_argument("--hf_token", type=str, default=None, help="Hugging Face Access Token to access PyAnnote gated models")
+    parser.add_argument("--hf_token", type=str, default=None, help="Hugging Face Access Token to access PyAnnote gated models; prefer the HF_TOKEN environment variable, since command-line arguments are visible to other users in the process list")
 
     parser.add_argument("--print_progress", type=str2bool, default = False, help = "if True, progress will be printed in transcribe() and align() methods.")
     parser.add_argument("--version", "-V", action="version", version=f"%(prog)s {importlib.metadata.version('whisperx')}",help="Show whisperx version information and exit")

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -50,7 +50,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
 
     return_char_alignments: bool = args.pop("return_char_alignments")
 
-    hf_token: str = args.pop("hf_token")
+    hf_token: str = args.pop("hf_token") or os.environ.get("HF_TOKEN")
     vad_method: str = args.pop("vad_method")
     vad_onset: float = args.pop("vad_onset")
     vad_offset: float = args.pop("vad_offset")
@@ -209,7 +209,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
     if diarize:
         if hf_token is None:
             logger.warning(
-                "No --hf_token provided, needs to be saved in environment variable, otherwise will throw error loading diarization model"
+                "No Hugging Face token provided: pass --hf_token or set the HF_TOKEN environment variable, otherwise will throw error loading diarization model"
             )
         tmp_results = results
         logger.info("Performing diarization...")


### PR DESCRIPTION
Fixes #1457.

## The problem

`--hf_token` is the only way to give whisperx the Hugging Face token needed for the gated pyannote diarization models, so the secret has to travel through `argv` — where it is readable by any other user on the host via the process list (`ps`, `/proc/<pid>/cmdline`), and where it lands in shell history.

The code already implies an environment variable exists. When the token is missing, `transcribe.py` warns:

> No --hf_token provided, needs to be saved in environment variable, otherwise will throw error loading diarization model

but nothing in the repo ever reads one — `--hf_token` is `default=None` in `__main__.py:77` and is used as-is. That is what the issue reports.

## The change

Fall back to the standard `HF_TOKEN` environment variable when the flag is absent; the flag still wins when both are set.

```python
hf_token: str = args.pop("hf_token") or os.environ.get("HF_TOKEN")
```

Plus the help text for `--hf_token`, and the warning above, now name both sources.

## Why the fallback is applied after parsing

The obvious spelling — `default=os.environ.get("HF_TOKEN")` on the `add_argument` call — leaks the secret, because the parser is built with `argparse.ArgumentDefaultsHelpFormatter`, which appends `(default: ...)` to every option. `whisperx --help` would print the token to the terminal. Checked both ways:

```
A) env var wired in as the argparse default
   token appears in --help: True
B) default stays None, env resolved after parsing (this PR)
   token appears in --help: False

resolution: args.pop('hf_token') or os.environ.get('HF_TOKEN')
   env only               -> hf_from_env
   cli wins over env      -> hf_from_cli
   cli only               -> hf_from_cli
   neither                -> None
```

The `neither` case is unchanged from today: `hf_token` stays `None`, the warning fires, and `DiarizationPipeline` is constructed exactly as before — so this is additive for anyone already passing `--hf_token`.

I used `HF_TOKEN` since that is the variable `huggingface_hub` itself reads. Happy to also honour the legacy `HUGGING_FACE_HUB_TOKEN`, or to switch to a file-based option as the issue suggests, if you would prefer either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
