### PR TITLE
docs: fix --condition_on_prev_text flag name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Transcription differences from openai's whisper:
 
 1. Transcription without timestamps. To enable single pass batching, whisper inference is performed `--without_timestamps True`, this ensures 1 forward pass per sample in the batch. However, this can cause discrepancies the default whisper output.
 2. VAD-based segment transcription, unlike the buffered transcription of openai's. In the WhisperX paper we show this reduces WER, and enables accurate batched inference
-3. `--condition_on_prev_text` is set to `False` by default (reduces hallucination)
+3. `--condition_on_previous_text` is set to `False` by default (reduces hallucination)
 
 <h2 align="left" id="limitations">Limitations ⚠️</h2>
 


### PR DESCRIPTION
The README (line 230) refers to `--condition_on_prev_text`, but the CLI defines the option as `--condition_on_previous_text` in `whisperx/__main__.py`:

```python
parser.add_argument("--condition_on_previous_text", type=str2bool, default=False, ...)
```

`--condition_on_prev_text` is not a valid prefix of the real option (they diverge after `prev`), so argparse rejects it with `unrecognized arguments: --condition_on_prev_text`. This corrects the flag name so the documented command works.

Docs-only, no functional change.
