### PR TITLE
Specify master branch for loading Silero via torch hub

### DIFF
--- a/whisperx/vads/silero.py
+++ b/whisperx/vads/silero.py
@@ -23,7 +23,7 @@ class Silero(Vad):
 
         self.vad_onset = kwargs['vad_onset']
         self.chunk_size = kwargs['chunk_size']
-        self.vad_pipeline, vad_utils = torch.hub.load(repo_or_dir='snakers4/silero-vad',
+        self.vad_pipeline, vad_utils = torch.hub.load(repo_or_dir='snakers4/silero-vad:master',
                                                       model='silero_vad',
                                                       force_reload=False,
                                                       onnx=False,


### PR DESCRIPTION
At the moment, torch tries loading from the main branch first and only then loads from the master branch. We can avoid this redundant attempt and speed up things a little bit. 

In fact, torch [always tries to check](https://github.com/pytorch/pytorch/blob/6f3baa6a03fc8169fed417c1470455cb6d3c31ef/torch/hub.py#L201) for existence of the `main` branch first sending an HTTP request to GitHub, even if a cached version of the model already exists on disk.