### PR TITLE
Split Chinese and Japanese into sentences during alignment

### DIFF
--- a/tests/test_cjk_sentence_splitting.py
+++ b/tests/test_cjk_sentence_splitting.py
@@ -1,0 +1,335 @@
+"""Test sentence splitting for languages written without spaces."""
+
+import torch
+from unittest.mock import MagicMock
+
+from whisperx import alignment
+from whisperx.alignment import align, LANGUAGES_WITHOUT_SPACES
+from whisperx.utils import CJKSentenceSplitter, PUNKT_LANGUAGES
+
+ZH = "我要给他一个教训。人家帮你是人情。你已经死了。"
+JA = "私は彼に教訓を与えます。手伝うのは人情です。もう終わりです。"
+
+
+class TestCJKSentenceSplitter:
+    """The splitter itself, without loading an alignment model."""
+
+    def setup_method(self):
+        self.splitter = CJKSentenceSplitter()
+
+    def spans(self, text):
+        return list(self.splitter.span_tokenize(text))
+
+    def test_chinese_splits_on_terminators(self):
+        assert len(self.spans(ZH)) == 3
+
+    def test_japanese_splits_on_terminators(self):
+        assert len(self.spans(JA)) == 3
+
+    def test_spans_slice_back_to_the_sentences(self):
+        assert [ZH[a:b] for a, b in self.spans(ZH)] == [
+            "我要给他一个教训。",
+            "人家帮你是人情。",
+            "你已经死了。",
+        ]
+
+    def test_terminator_stays_with_its_sentence(self):
+        for _, end in self.spans(ZH):
+            assert ZH[end - 1] == "。"
+
+    def test_spans_are_contiguous_when_there_is_no_whitespace(self):
+        prev_end = 0
+        for start, end in self.spans(ZH):
+            assert start == prev_end
+            assert end > start
+            prev_end = end
+        assert prev_end == len(ZH)
+
+    def test_whitespace_between_sentences_is_skipped(self):
+        """Punkt leaves the separator out of its spans, so this does too."""
+        assert self.spans("これは。 次の文。") == [(0, 4), (5, 9)]
+        assert self.spans("これは。\n次の文。") == [(0, 4), (5, 9)]
+
+    def test_fullwidth_period_does_not_split_fullwidth_numbers(self):
+        """． is a terminator in the 「，．」 style but also a decimal point."""
+        text = "値は３．１４です．次の文．"
+        assert [text[a:b] for a, b in self.spans(text)] == ["値は３．１４です．", "次の文．"]
+
+    def test_fullwidth_period_still_ends_a_sentence(self):
+        text = "これは文です．次の文です．"
+        assert len(self.spans(text)) == 2
+
+    def test_terminator_inside_a_quotation_still_splits(self):
+        """Deliberate: tracking bracket depth would let one unclosed quote
+        swallow every later sentence, which is the bug being fixed."""
+        text = "彼は「もう終わりです。まだです」と言った。"
+        assert len(self.spans(text)) > 1
+
+    def test_run_of_terminators_ends_one_sentence(self):
+        text = "本当に！？信じられない。"
+        assert [text[a:b] for a, b in self.spans(text)] == ["本当に！？", "信じられない。"]
+
+    def test_closing_bracket_stays_with_its_sentence(self):
+        text = "彼は「もう終わりです。」と言った。"
+        assert [text[a:b] for a, b in self.spans(text)] == [
+            "彼は「もう終わりです。」",
+            "と言った。",
+        ]
+
+    def test_halfwidth_terminators(self):
+        text = "そうですか?はい!"
+        assert [text[a:b] for a, b in self.spans(text)] == ["そうですか?", "はい!"]
+
+    def test_halfwidth_period_does_not_split_numbers(self):
+        text = "値は3.14です。次の文。"
+        assert [text[a:b] for a, b in self.spans(text)] == ["値は3.14です。", "次の文。"]
+
+    def test_halfwidth_period_followed_by_space_still_splits(self):
+        """The English punkt fallback used to split these, so not splitting
+        them would be a regression for CJK text punctuated with ASCII."""
+        text = "你好世界. 再见朋友."
+        assert [text[a:b] for a, b in self.spans(text)] == ["你好世界.", "再见朋友."]
+
+    def test_halfwidth_period_without_a_following_space_does_not_split(self):
+        """Punkt does not split this either, so match it."""
+        text = "你好世界.再见朋友."
+        assert len(self.spans(text)) == 1
+
+    def test_halfwidth_bang_inside_a_latin_word_does_not_split(self):
+        text = "Yahoo!ニュースを見た。"
+        assert len(self.spans(text)) == 1
+
+    def test_question_mark_inside_a_url_does_not_split(self):
+        text = "https://example.com/a?b=1を開く。"
+        assert len(self.spans(text)) == 1
+
+    def test_halfwidth_bang_after_kana_still_splits(self):
+        text = "はい!そうです。"
+        assert [text[a:b] for a, b in self.spans(text)] == ["はい!", "そうです。"]
+
+    def test_ascii_quote_is_not_treated_as_a_closer(self):
+        """The same character opens and closes, so absorbing it would take the
+        next sentence's opening quote."""
+        text = '終わりです。"次は何ですか。'
+        assert [text[a:b] for a, b in self.spans(text)] == [
+            "終わりです。", '"次は何ですか。']
+
+    def test_text_without_a_terminator_is_one_sentence(self):
+        text = "これはテストです"
+        assert self.spans(text) == [(0, len(text))]
+
+    def test_empty_text_has_no_sentences(self):
+        assert self.spans("") == []
+
+    def test_trailing_whitespace_is_excluded(self):
+        """Punkt leaves trailing whitespace out of its spans, so this does too."""
+        assert self.spans("これはテストです。  ") == [(0, 9)]
+        assert self.spans("これはテストです  ") == [(0, 8)]
+
+
+class TestSplitterSelection:
+    """Which splitter each language gets. These monkeypatch the loader so they
+    assert which tokenizer is requested without downloading NLTK data."""
+
+    def _requested(self, monkeypatch, lang):
+        """The punkt model align() asks for, or the CJK splitter it picks."""
+        asked = []
+
+        def fake_load(path):
+            asked.append(path)
+            return object()
+
+        monkeypatch.setattr(alignment, "nltk_load", fake_load)
+        if lang in LANGUAGES_WITHOUT_SPACES:
+            return CJKSentenceSplitter, asked
+        return type(alignment._load_punkt(lang)), asked
+
+    def test_cjk_languages_do_not_load_a_punkt_model(self, monkeypatch):
+        for lang in ("zh", "ja"):
+            _, asked = self._requested(monkeypatch, lang)
+            assert asked == [], f"{lang} should not need punkt, asked for {asked}"
+
+    def test_each_mapped_language_asks_for_its_own_model(self, monkeypatch):
+        for lang, expected in PUNKT_LANGUAGES.items():
+            _, asked = self._requested(monkeypatch, lang)
+            assert asked == [f"tokenizers/punkt_tab/{expected}.pickle"]
+
+    def test_unmapped_language_asks_for_english(self, monkeypatch):
+        for lang in ("xx", "ko", "ar"):
+            _, asked = self._requested(monkeypatch, lang)
+            assert asked == ["tokenizers/punkt_tab/english.pickle"]
+
+    def test_align_uses_the_cjk_splitter_for_cjk_only(self):
+        """The list align() branches on is the one the splitter is built for."""
+        assert set(LANGUAGES_WITHOUT_SPACES) == {"ja", "zh"}
+        assert not set(LANGUAGES_WITHOUT_SPACES) & set(PUNKT_LANGUAGES)
+
+
+class TestAlignSplitsCJKSegments:
+    """align() end-to-end, so the fix is checked where it actually runs."""
+
+    # Chinese alignment models are phoneme-based, so the dictionary here stands
+    # in for one: no CJK character is in it and every one takes the wildcard
+    # path. That is enough to exercise sentence splitting, which is what
+    # decides how many segments come back.
+    DICTIONARY = {"<pad>": 0, "a": 1, "|": 2}
+
+    def _run_align(self, text, language, duration=6.0, num_frames=120,
+                   return_char_alignments=False):
+        torch.manual_seed(0)
+        emission = torch.full((num_frames, 3), -5.0)
+        emission[:, 0] = -1.0
+        model = MagicMock()
+        model.return_value = (emission.unsqueeze(0), None)
+
+        return align(
+            transcript=[{"text": text, "start": 0.0, "end": duration}],
+            model=model,
+            align_model_metadata={
+                "language": language,
+                "dictionary": self.DICTIONARY,
+                "type": "torchaudio",
+            },
+            audio=torch.randn(int(duration * 16000)),
+            device="cpu",
+            return_char_alignments=return_char_alignments,
+        )
+
+    def test_chinese_segment_splits_into_sentences(self):
+        """Before the fix this returned one segment holding all three sentences."""
+        result = self._run_align(ZH, "zh")
+        assert len(result["segments"]) == 3
+
+    def test_japanese_segment_splits_into_sentences(self):
+        result = self._run_align(JA, "ja")
+        assert len(result["segments"]) == 3
+
+    def test_each_chinese_sentence_keeps_its_own_text(self):
+        result = self._run_align(ZH, "zh")
+        assert [s["text"] for s in result["segments"]] == [
+            "我要给他一个教训。",
+            "人家帮你是人情。",
+            "你已经死了。",
+        ]
+
+    def test_words_do_not_leak_across_the_sentence_boundary(self):
+        """CJK spans are adjacent, so an inclusive end would take the next
+        sentence's first character. The words of each segment should be exactly
+        its own text."""
+        for text in (ZH, " " + ZH):
+            result = self._run_align(text, "zh")
+            for seg in result["segments"]:
+                assert "".join(w["word"] for w in seg["words"]) == seg["text"].strip()
+
+    def test_english_sentences_still_carry_their_own_words(self):
+        """The same boundary check for the punkt path, which must be unchanged."""
+        dictionary = {"<pad>": 0, "|": 1}
+        for i, c in enumerate("abcdefghijklmnopqrstuvwxyz", 2):
+            dictionary[c] = i
+        torch.manual_seed(0)
+        emission = torch.full((160, 28), -5.0)
+        emission[:, 0] = -1.0
+        model = MagicMock()
+        model.return_value = (emission.unsqueeze(0), None)
+        result = align(
+            transcript=[{"text": "I teach him. Helping is kind. You are done.",
+                         "start": 0.0, "end": 8.0}],
+            model=model,
+            align_model_metadata={"language": "en", "dictionary": dictionary,
+                                  "type": "torchaudio"},
+            audio=torch.randn(128000),
+            device="cpu",
+        )
+        assert [s["text"] for s in result["segments"]] == [
+            "I teach him.", "Helping is kind.", "You are done."]
+        for seg in result["segments"]:
+            assert " ".join(w["word"] for w in seg["words"]) == seg["text"]
+
+    def test_char_alignments_cover_the_whole_cjk_segment(self):
+        result = self._run_align(ZH, "zh", return_char_alignments=True)
+        rebuilt = "".join(c["char"] for s in result["segments"] for c in s["chars"])
+        assert rebuilt == ZH
+        for seg in result["segments"]:
+            assert "".join(c["char"] for c in seg["chars"]) == seg["text"]
+
+    def test_sentence_timestamps_are_ordered_and_in_range(self):
+        result = self._run_align(ZH, "zh", duration=6.0)
+        prev_end = 0.0
+        for seg in result["segments"]:
+            assert seg["start"] >= prev_end
+            assert seg["end"] >= seg["start"]
+            assert seg["end"] <= 6.0
+            prev_end = seg["end"]
+
+
+class TestPunktPathBoundaries:
+    """The exclusive span end also touches the punkt path, so pin it here."""
+
+    DICTIONARY = {"<pad>": 0, "|": 1}
+    for _i, _c in enumerate("abcdefghijklmnopqrstuvwxyz", 2):
+        DICTIONARY[_c] = _i
+    del _i, _c
+
+    def _run_align(self, text, return_char_alignments=False):
+        torch.manual_seed(0)
+        num_frames = 220
+        emission = torch.full((num_frames, 28), -5.0)
+        emission[:, 0] = -1.0
+        for j, ch in enumerate(text.lower()):
+            if ch in self.DICTIONARY:
+                centre = int((j + 1) * num_frames / (len(text) + 1))
+                for t in range(max(0, centre - 2), min(num_frames, centre + 2)):
+                    emission[t, self.DICTIONARY[ch]] = 2.0
+                    emission[t, 0] = -3.0
+        model = MagicMock()
+        model.return_value = (emission.unsqueeze(0), None)
+        return align(
+            transcript=[{"text": text, "start": 0.0, "end": 8.0}],
+            model=model,
+            align_model_metadata={"language": "en", "dictionary": self.DICTIONARY,
+                                  "type": "torchaudio"},
+            audio=torch.randn(128000),
+            device="cpu",
+            return_char_alignments=return_char_alignments,
+        )
+
+    def test_char_alignments_cover_every_character(self):
+        """Punkt leaves the separating whitespace out of its spans. Those
+        characters still have to appear in the char output."""
+        text = "One apple here. Two pears there. Three plums now."
+        result = self._run_align(text, return_char_alignments=True)
+        rebuilt = "".join(c["char"] for s in result["segments"] for c in s["chars"])
+        assert rebuilt == text
+
+    def test_char_alignments_cover_multiple_separating_spaces(self):
+        text = "One apple here.  Two pears there.  Three plums now."
+        result = self._run_align(text, return_char_alignments=True)
+        rebuilt = "".join(c["char"] for s in result["segments"] for c in s["chars"])
+        assert rebuilt == text
+
+    def test_newline_separated_sentences_do_not_touch(self):
+        """A separator that is not a plain space used to be counted as part of
+        the sentence before it, so one sentence ended exactly where the next
+        began."""
+        result = self._run_align("One apple here.\nTwo pears there.\nThree plums now.")
+        segments = result["segments"]
+        assert len(segments) == 3
+        for earlier, later in zip(segments, segments[1:]):
+            assert earlier["end"] < later["start"]
+
+    def test_adjacent_punkt_spans_do_not_leak_words(self):
+        """Punkt returns adjacent spans when a boundary has no whitespace after
+        it, e.g. 'Hello!!!Goodbye.' -> [(0, 7), (7, 16)]. Those hit the same
+        boundary problem as CJK: the first sentence took the next one's opening
+        character."""
+        result = self._run_align("Hello!!!Goodbye.")
+        assert len(result["segments"]) == 2
+        for seg in result["segments"]:
+            assert " ".join(w["word"] for w in seg["words"]) == seg["text"]
+
+    def test_single_space_sentences_keep_their_own_words(self):
+        result = self._run_align("One apple here. Two pears there.")
+        assert [s["text"] for s in result["segments"]] == [
+            "One apple here.", "Two pears there."]
+        for seg in result["segments"]:
+            assert " ".join(w["word"] for w in seg["words"]) == seg["text"]

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -12,7 +12,12 @@ import torchaudio
 from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
 
 from whisperx.audio import SAMPLE_RATE, load_audio
-from whisperx.utils import interpolate_nans, CJKSentenceSplitter, PUNKT_LANGUAGES
+from whisperx.utils import (
+    interpolate_nans,
+    CJKSentenceSplitter,
+    LANGUAGES_WITHOUT_SPACES,
+    PUNKT_LANGUAGES,
+)
 from whisperx.schema import (
     AlignedTranscriptionResult,
     SingleSegment,
@@ -27,7 +32,6 @@ from whisperx.log_utils import get_logger
 
 logger = get_logger(__name__)
 
-LANGUAGES_WITHOUT_SPACES = ["ja", "zh"]
 
 DEFAULT_ALIGN_MODELS_TORCH = {
     "en": "WAV2VEC2_ASR_BASE_960H",

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -12,7 +12,7 @@ import torchaudio
 from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
 
 from whisperx.audio import SAMPLE_RATE, load_audio
-from whisperx.utils import interpolate_nans, PUNKT_LANGUAGES
+from whisperx.utils import interpolate_nans, CJKSentenceSplitter, PUNKT_LANGUAGES
 from whisperx.schema import (
     AlignedTranscriptionResult,
     SingleSegment,
@@ -114,6 +114,21 @@ def load_align_model(language_code: str, device: str, model_name: Optional[str] 
     return align_model, align_metadata
 
 
+def _load_punkt(model_lang: str):
+    """Punkt sentence tokenizer for a language, falling back to English."""
+    punkt_lang = PUNKT_LANGUAGES.get(model_lang, 'english')
+    try:
+        return nltk_load(f'tokenizers/punkt_tab/{punkt_lang}.pickle')
+    except LookupError as e:
+        logger.info("Downloading NLTK punkt_tab data for sentence splitting...")
+        if not nltk.download('punkt_tab', quiet=True):
+            raise RuntimeError(
+                "Failed to download NLTK 'punkt_tab' data, which is required for sentence splitting. "
+                "Check your network connection, or install it manually with: python -m nltk.downloader punkt_tab"
+            ) from e
+        return nltk_load(f'tokenizers/punkt_tab/{punkt_lang}.pickle')
+
+
 def align(
     transcript: Iterable[SingleSegment],
     model: torch.nn.Module,
@@ -143,18 +158,12 @@ def align(
     model_lang = align_model_metadata["language"]
     model_type = align_model_metadata["type"]
 
-    # Use language-specific Punkt model if available otherwise we fallback to English.
-    punkt_lang = PUNKT_LANGUAGES.get(model_lang, 'english')
-    try:
-        sentence_splitter = nltk_load(f'tokenizers/punkt_tab/{punkt_lang}.pickle')
-    except LookupError as e:
-        logger.info("Downloading NLTK punkt_tab data for sentence splitting...")
-        if not nltk.download('punkt_tab', quiet=True):
-            raise RuntimeError(
-                "Failed to download NLTK 'punkt_tab' data, which is required for sentence splitting. "
-                "Check your network connection, or install it manually with: python -m nltk.downloader punkt_tab"
-            ) from e
-        sentence_splitter = nltk_load(f'tokenizers/punkt_tab/{punkt_lang}.pickle')
+    # Punkt cannot segment languages that are written without spaces, and the
+    # English fallback returns the whole segment as one sentence for them.
+    if model_lang in LANGUAGES_WITHOUT_SPACES:
+        sentence_splitter = CJKSentenceSplitter()
+    else:
+        sentence_splitter = _load_punkt(model_lang)
 
     # 1. Preprocess to keep only characters in dictionary
     total_segments = len(transcript)
@@ -333,9 +342,14 @@ def align(
         aligned_subsegments = []
         # assign sentence_idx to each character index
         char_segments_arr["sentence-idx"] = None
-        for sdx2, (sstart, send) in enumerate(segment_data[sdx]["sentence_spans"]):
-            curr_chars = char_segments_arr.loc[(char_segments_arr.index >= sstart) & (char_segments_arr.index <= send)]
-            char_segments_arr.loc[(char_segments_arr.index >= sstart) & (char_segments_arr.index <= send), "sentence-idx"] = sdx2
+        sentence_spans = segment_data[sdx]["sentence_spans"]
+        for sdx2, (sstart, send) in enumerate(sentence_spans):
+            # `send` is exclusive, as it is in the spans punkt returns. Including
+            # it only ever picked up the space between two sentences, until CJK
+            # spans arrived: those are adjacent, so it took the next sentence's
+            # first character along with its timing.
+            curr_chars = char_segments_arr.loc[(char_segments_arr.index >= sstart) & (char_segments_arr.index < send)]
+            char_segments_arr.loc[(char_segments_arr.index >= sstart) & (char_segments_arr.index < send), "sentence-idx"] = sdx2
 
             sentence_text = text[sstart:send]
             sentence_start = curr_chars["start"].min()
@@ -392,11 +406,18 @@ def align(
             aligned_subsegments.append(subsegment)
 
             if return_char_alignments:
-                curr_chars = curr_chars[["char", "start", "end", "score"]]
-                curr_chars.fillna(-1, inplace=True)
-                curr_chars = curr_chars.to_dict("records")
-                curr_chars = [{key: val for key, val in char.items() if val != -1} for char in curr_chars]
-                aligned_subsegments[-1]["chars"] = curr_chars
+                # Timing above stops at `send`, but the characters between two
+                # spans, the whitespace punkt leaves out, belong to no sentence
+                # and would drop out of the output entirely. Run to the start of
+                # the next span so `chars` still covers the whole segment. CJK
+                # spans are adjacent, so this is the same range for them.
+                char_end = sentence_spans[sdx2 + 1][0] if sdx2 + 1 < len(sentence_spans) else len(text)
+                out_chars = char_segments_arr.loc[(char_segments_arr.index >= sstart) & (char_segments_arr.index < char_end)]
+                out_chars = out_chars[["char", "start", "end", "score"]]
+                out_chars.fillna(-1, inplace=True)
+                out_chars = out_chars.to_dict("records")
+                out_chars = [{key: val for key, val in char.items() if val != -1} for char in out_chars]
+                aligned_subsegments[-1]["chars"] = out_chars
 
         aligned_subsegments = pd.DataFrame(aligned_subsegments)
         aligned_subsegments["start"] = interpolate_nans(aligned_subsegments["start"], method=interpolate_method)

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -126,6 +126,83 @@ TO_LANGUAGE_CODE = {
 
 LANGUAGES_WITHOUT_SPACES = ["ja", "zh"]
 
+# Sentence-ending punctuation for the languages in LANGUAGES_WITHOUT_SPACES.
+# 。！？ always end a sentence. The halfwidth forms and ． are ambiguous and are
+# qualified in CJKSentenceSplitter._ends_sentence below.
+CJK_TERMINATORS = "。！？．!?."
+
+# Closing brackets and quotes, which belong to the sentence they close, as in
+# 「もう終わりです。」 The ASCII " and ' are deliberately absent: the same
+# character opens and closes, so treating one as a closer would swallow the
+# opening quote of the following sentence.
+CJK_CLOSERS = "」』）］｝〉》”’)]}"
+
+CJK_DIGITS = "0123456789０１２３４５６７８９"
+
+
+class CJKSentenceSplitter:
+    """Sentence spans for languages written without spaces between words.
+
+    Punkt is trained on space-separated text with Latin punctuation, so it has
+    no basis for splitting Chinese or Japanese and returns the whole input as a
+    single span. Splitting on the CJK terminators instead gives one span per
+    sentence.
+
+    Exposes ``span_tokenize`` so it can be used wherever a punkt tokenizer is,
+    and follows punkt's conventions: ends are exclusive, and whitespace between
+    or after sentences is left out of the spans.
+
+    A terminator inside a quotation is treated as a sentence end, the same way
+    punkt treats one in English. Tracking bracket depth instead would mean an
+    unclosed quote, which speech recognition produces often, swallows every
+    later sentence in the segment, which is the bug this class exists to fix.
+    """
+
+    @staticmethod
+    def _ends_sentence(text: str, i: int) -> bool:
+        """Whether the terminator at `i` really ends a sentence."""
+        char = text[i]
+        prev = text[i - 1] if i else ""
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if char == ".":
+            # Halfwidth "." is a decimal point at least as often as a
+            # terminator. Punkt only breaks on it when whitespace follows, so
+            # do the same: "3.14" stays whole and "你好. 再见." still splits.
+            return nxt == "" or nxt.isspace()
+        if char == "．":
+            # Fullwidth "．" ends sentences in the 「，．」 style, where nothing
+            # follows it, but it is also the fullwidth decimal point.
+            return not (prev in CJK_DIGITS and nxt in CJK_DIGITS)
+        if char in "!?":
+            # Halfwidth "!" and "?" appear inside Latin words and URLs that
+            # are embedded in CJK text, as in Yahoo!ニュース and ?q=1.
+            return not (prev.isascii() and prev.isalnum())
+        return True
+
+    def span_tokenize(self, text: str):
+        start = i = 0
+        n = len(text)
+        while i < n:
+            if text[i] not in CJK_TERMINATORS or not self._ends_sentence(text, i):
+                i += 1
+                continue
+            end = i + 1
+            # A run of terminators ends one sentence, not several, as in ！？
+            while end < n and text[end] in CJK_TERMINATORS:
+                end += 1
+            while end < n and text[end] in CJK_CLOSERS:
+                end += 1
+            yield start, end
+            i = end
+            while i < n and text[i].isspace():
+                i += 1
+            start = i
+        # Trailing text with no terminator is still a sentence.
+        tail = text[start:].rstrip()
+        if tail:
+            yield start, start + len(tail)
+
+
 # Mapping of language codes to NLTK Punkt tokenizer model names
 PUNKT_LANGUAGES = {
     'cs': 'czech',


### PR DESCRIPTION
Fixes #1310.

## What happens

`align()` picks a punkt tokenizer by language code and falls back to English when there is no model for the language:

```python
punkt_lang = PUNKT_LANGUAGES.get(model_lang, 'english')
```

`PUNKT_LANGUAGES` has 19 entries and none of them is `zh` or `ja`, so both get the English model. That model is trained on space-separated text with Latin punctuation, so it has nothing to go on and hands back the whole segment as one span:

```python
>>> sp = nltk.data.load('tokenizers/punkt_tab/english.pickle')
>>> list(sp.span_tokenize("我要给他一个教训。人家帮你是人情。你已经死了。"))
[(0, 23)]
```

Every sentence in a segment then shares one start and end time. Here is `align()` on that same text before and after, with a stub model so the numbers are reproducible:

```
before          after
1 segment       3 segments
0.00 -> 1.15    0.00 -> 0.45  我要给他一个教训。
                0.45 -> 0.85  人家帮你是人情。
                0.85 -> 1.15  你已经死了。
```

## On the chunk_size suggestion in the thread

`--chunk_size 10` came up in the issue as a workaround. It does not reach this code. `chunk_size` is a VAD merging parameter, consumed in `asr.py` before alignment runs, and the string `chunk_size` does not appear in `alignment.py` at all. Smaller chunks make segments shorter, so fewer of them happen to contain more than one sentence, but any segment that still holds two sentences comes back unsplit. The reporter said as much in the thread.

## The change

`LANGUAGES_WITHOUT_SPACES = ["ja", "zh"]` is already defined in `alignment.py` and already branched on for word indexing and for joining text without spaces. This adds a sentence splitter for the same list and keeps punkt for every other language, so sentence splitting agrees with the rest of the file instead of being the one place that ignores it.

`。！？` always end a sentence. The ambiguous marks are qualified, because each of them is something other than a terminator often enough to matter:

- **Halfwidth `.`** ends a sentence only when whitespace or end-of-text follows. That is what punkt does, so `你好世界. 再见朋友.` still splits into two (the English fallback got this case right, and an unqualified rule would have regressed it) while `3.14` stays whole.
- **Fullwidth `．`** is a terminator in the `，．` style, where nothing follows it, but it is also the fullwidth decimal point, so it does not split between two digits. `値は３．１４です．次の文．` gives two sentences.
- **Halfwidth `!` and `?`** do not split when the preceding character is ASCII alphanumeric, because they turn up inside Latin words and URLs embedded in CJK text. `Yahoo!ニュースを見た。` and `https://example.com/a?b=1を開く。` each stay one sentence, while `はい!そうです。` splits.
- A run of terminators (`！？`) ends one sentence, and an unambiguous closing bracket or quote stays with the sentence it closes, as in `「もう終わりです。」`. ASCII `"` and `'` are **not** treated as closers: the same character opens and closes, so absorbing one would eat the next sentence's opening quote.
- A terminator inside a quotation still splits. This matches punkt, which does the same in English (`He said "It is over." and left.` splits after the quote). I tried tracking bracket depth instead and backed it out: speech recognition drops closing quotes often, and one unclosed `「` would then swallow every later sentence in the segment, which is the bug being fixed here.

## The span end, and what it changes for other languages

I also changed the sentence-to-character assignment to treat the span end as exclusive, which is what `span_tokenize` returns:

```python
-  (char_segments_arr.index >= sstart) & (char_segments_arr.index <= send)
+  (char_segments_arr.index >= sstart) & (char_segments_arr.index < send)
```

Without this, CJK spans are adjacent, so the first sentence keeps the next one's opening character and its timestamp:

```
segment text : 我要给他一个教训。
segment words: 我要给他一个教训。人      <- 人 belongs to the next sentence
```

**This is not a no-op for punkt languages.** I originally thought it was, on the assumption that punkt spans always have the separating space between them. That is wrong, and I am flagging it rather than burying it. Running `align()` over 28 case/flag combinations in en, de, fr, es and an unmapped code, 19 are identical to current main and 5 inputs differ. All five differences are cases where main is doing something wrong:

1. **Punkt does return adjacent spans**, whenever a boundary has no whitespace after it: `'Hello!!!Goodbye.'` gives `[(0, 7), (7, 16)]`. On main those hit the same boundary problem as CJK. Segment one has text `Hello!!` but words `Hello!!!`, having taken the `!` that belongs to segment two. This change fixes that.
2. **Sentences separated by something other than a plain space** (newline, tab, CRLF, NBSP). Only U+0020 is filtered by the existing `char != ' '` guards, so on main the separator's own alignment time became the sentence's end time, and one sentence ended exactly where the next began (`0.582 -> 0.582`). Now each sentence ends at its last real character.
3. **`return_char_alignments=True`.** The characters between two spans belong to no sentence, so a naive exclusive end drops them out of the output. I kept the tight range for timing and gave the char output its own range that runs to the start of the next span. Full coverage is now exact, including the case of two spaces between sentences, where main silently loses a character (49 of 51 come back).

If you would rather this PR only touch CJK, I can gate the exclusive end on `model_lang in LANGUAGES_WITHOUT_SPACES` and send the punkt-path fixes separately. Say the word and I will split it.

One thing to flag: open PR #1453 rewrites this block and deliberately keeps the inclusive selection, with the comment "Preserve the existing inclusive character selection at `send`". So this is not just a textual conflict with that PR, it is a disagreement about what the selection should be, and it is worth deciding which behaviour you want before either lands.

## Tests

`tests/test_cjk_sentence_splitting.py`, 38 tests. The 26 splitter and selection tests need no NLTK data at all (they monkeypatch the loader); the 12 `align()` tests use the same punkt data the existing test file already needs. No model download, same mock style as `tests/test_word_timestamp_interpolation.py`.

Being straight about what they cover: the ones that guard against regression are the `align()` level tests, of which 3 fail on main for the CJK bug and 3 more fail on main for the punkt-path cases above. The splitter unit tests are specification tests for new code, not regression tests, since the code does not exist on main to fail against. Existing tests are unchanged and still pass: 50 total.

## On #597

I looked at it. #597 reports the same underlying problem, on the same transcript this PR's test fixture is taken from, and this change does split those cues. Its title asks about `--max_line_width` and `--max_line_count` in the subtitle writers, which I have not touched, so I have not marked it closed. Worth a look from someone who knows that code.

## Note

Written and tested by me. I used Claude Code while working on it, and I have verified every claim above myself by running it. I had it reviewed before opening it, which is how the punkt-path differences, the fullwidth decimal case, the ASCII-quote closer and the `Yahoo!` case were caught. My first draft claimed the change was a no-op for non-CJK languages and did not qualify the ASCII period, which would have regressed CJK text punctuated with halfwidth periods. Both are fixed above.
