### PR TITLE
Make torchaudio optional with Hugging Face fallback for align models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "pyannote-audio>=4.0.0",
     "huggingface-hub>=0.28.1",
     "torch~=2.8.0",
-    "torchaudio~=2.8.0",
     "torchvision~=0.23.0",
     "torchcodec>=0.6.0,<0.8.0; (sys_platform == 'linux' and platform_machine == 'x86_64') or sys_platform == 'darwin' or sys_platform == 'win32'",
     "transformers>=4.48.0",
@@ -28,6 +27,9 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest"]
+# torchaudio 仅用于 torchaudio.pipelines 加载对齐模型（可选路径）。
+# 无需 torchaudio 的平台（如昇腾/ARM aarch64，无 torchaudio wheel）默认不安装它。
+align-torch = ["torchaudio~=2.8.0"]
 
 [project.scripts]
 whisperx = "whisperx.__main__:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,9 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest"]
-# torchaudio 仅用于 torchaudio.pipelines 加载对齐模型（可选路径）。
-# 无需 torchaudio 的平台（如昇腾/ARM aarch64，无 torchaudio wheel）默认不安装它。
+# torchaudio is only used for loading align models via torchaudio.pipelines
+# (an optional path). Platforms without torchaudio wheels (e.g. Ascend /
+# Linux aarch64) skip installing it and use the HF fallback instead.
 align-torch = ["torchaudio~=2.8.0"]
 
 [project.scripts]

--- a/tests/test_align_model_fallback.py
+++ b/tests/test_align_model_fallback.py
@@ -1,0 +1,20 @@
+"""Tests for torchaudio-optional alignment model loading."""
+
+import whisperx.alignment as A
+
+
+def test_default_torch_models_have_hf_fallback():
+    """每个 torchaudio.pipelines 默认对齐模型都应有 HF 等价兜底。
+
+    该兜底让没有 torchaudio（如昇腾/ARM aarch64，无 torchaudio wheel）的
+    平台也能用对应的 Hugging Face wav2vec2 checkpoint 执行 forced alignment。
+    """
+    assert set(A.DEFAULT_ALIGN_MODELS_TORCH.values()) == set(
+        A.TORCHAUDIO_PIPELINE_TO_HF.keys()
+    )
+
+
+def test_hf_fallback_names_are_valid_checkpoints():
+    """HF 兜底名应为 facebook 官方 wav2vec2 checkpoint。"""
+    for name in A.TORCHAUDIO_PIPELINE_TO_HF.values():
+        assert name.startswith("facebook/"), name

--- a/tests/test_align_model_fallback.py
+++ b/tests/test_align_model_fallback.py
@@ -1,20 +1,48 @@
 """Tests for torchaudio-optional alignment model loading."""
 
+from unittest import mock
+
 import whisperx.alignment as A
 
 
 def test_default_torch_models_have_hf_fallback():
-    """每个 torchaudio.pipelines 默认对齐模型都应有 HF 等价兜底。
-
-    该兜底让没有 torchaudio（如昇腾/ARM aarch64，无 torchaudio wheel）的
-    平台也能用对应的 Hugging Face wav2vec2 checkpoint 执行 forced alignment。
-    """
+    """Every default torchaudio.pipelines align model should have an HF
+    equivalent, so platforms without torchaudio wheels (e.g. Ascend /
+    Linux aarch64) can still run forced alignment via Hugging Face."""
     assert set(A.DEFAULT_ALIGN_MODELS_TORCH.values()) == set(
         A.TORCHAUDIO_PIPELINE_TO_HF.keys()
     )
 
 
 def test_hf_fallback_names_are_valid_checkpoints():
-    """HF 兜底名应为 facebook 官方 wav2vec2 checkpoint。"""
+    """HF fallback names should be official facebook wav2vec2 checkpoints."""
     for name in A.TORCHAUDIO_PIPELINE_TO_HF.values():
         assert name.startswith("facebook/"), name
+
+
+def test_load_align_model_falls_back_to_hf_when_torchaudio_missing():
+    """With torchaudio absent, a torchaudio.pipelines default model name must
+    be transparently remapped to its HF checkpoint and loaded via
+    Wav2Vec2 (the HuggingFace path), not crash."""
+    fake_vocab = {"<pad>": 0, "a": 1, "b": 2}
+    fake_processor = mock.MagicMock()
+    fake_processor.tokenizer.get_vocab.return_value = fake_vocab
+    fake_model = mock.MagicMock()
+
+    with mock.patch.object(A, "torchaudio", None), mock.patch.object(
+        A, "Wav2Vec2Processor"
+    ) as proc_cls, mock.patch.object(A, "Wav2Vec2ForCTC") as model_cls:
+        proc_cls.from_pretrained.return_value = fake_processor
+        model_cls.from_pretrained.return_value = fake_model
+
+        model, metadata = A.load_align_model(
+            language_code="en", device="cpu"
+        )
+
+    assert model is fake_model.to.return_value  # returned after .to(device)
+    assert metadata["type"] == "huggingface"
+    assert metadata["dictionary"] == {c.lower(): i for c, i in fake_vocab.items()}
+    # the torchaudio bundle name was remapped to the HF checkpoint
+    remapped_name = proc_cls.from_pretrained.call_args.args[0]
+    assert remapped_name == A.TORCHAUDIO_PIPELINE_TO_HF["WAV2VEC2_ASR_BASE_960H"]
+    assert model_cls.from_pretrained.call_args.args[0] == remapped_name

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -8,7 +8,10 @@ from typing import Iterable, Optional, Union, List
 import numpy as np
 import pandas as pd
 import torch
-import torchaudio
+try:
+    import torchaudio
+except ImportError:
+    torchaudio = None
 from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
 
 from whisperx.audio import SAMPLE_RATE, load_audio
@@ -35,6 +38,17 @@ DEFAULT_ALIGN_MODELS_TORCH = {
     "de": "VOXPOPULI_ASR_BASE_10K_DE",
     "es": "VOXPOPULI_ASR_BASE_10K_ES",
     "it": "VOXPOPULI_ASR_BASE_10K_IT",
+}
+
+# torchaudio.pipelines 模型在 Hugging Face 上的等价 checkpoint。
+# torchaudio 无 Linux aarch64 wheel（昇腾/鲲鹏 ARM 等平台装不上），
+# 此时可用这些 HF 模型兜底加载对齐模型，使 forced alignment 仍可用。
+TORCHAUDIO_PIPELINE_TO_HF = {
+    "WAV2VEC2_ASR_BASE_960H": "facebook/wav2vec2-base-960h",
+    "VOXPOPULI_ASR_BASE_10K_FR": "facebook/wav2vec2-base-10k-voxpopuli-fr",
+    "VOXPOPULI_ASR_BASE_10K_DE": "facebook/wav2vec2-base-10k-voxpopuli-de",
+    "VOXPOPULI_ASR_BASE_10K_ES": "facebook/wav2vec2-base-10k-voxpopuli-es",
+    "VOXPOPULI_ASR_BASE_10K_IT": "facebook/wav2vec2-base-10k-voxpopuli-it",
 }
 
 DEFAULT_ALIGN_MODELS_HF = {
@@ -90,13 +104,16 @@ def load_align_model(language_code: str, device: str, model_name: Optional[str] 
                          f"then pass the model name via --align_model [MODEL_NAME]")
             raise ValueError(f"No default align-model for language: {language_code}")
 
-    if model_name in torchaudio.pipelines.__all__:
+    if torchaudio is not None and model_name in torchaudio.pipelines.__all__:
         pipeline_type = "torchaudio"
         bundle = torchaudio.pipelines.__dict__[model_name]
         align_model = bundle.get_model(dl_kwargs={"model_dir": model_dir}).to(device)
         labels = bundle.get_labels()
         align_dictionary = {c.lower(): i for i, c in enumerate(labels)}
     else:
+        # torchaudio 不可用时，将 torchaudio.pipelines 模型名兜底到 HF 等价 checkpoint
+        if torchaudio is None and model_name in TORCHAUDIO_PIPELINE_TO_HF:
+            model_name = TORCHAUDIO_PIPELINE_TO_HF[model_name]
         try:
             processor = Wav2Vec2Processor.from_pretrained(model_name, cache_dir=model_dir, local_files_only=model_cache_only)
             align_model = Wav2Vec2ForCTC.from_pretrained(model_name, cache_dir=model_dir, local_files_only=model_cache_only)

--- a/whisperx/alignment.py
+++ b/whisperx/alignment.py
@@ -10,8 +10,8 @@ import pandas as pd
 import torch
 try:
     import torchaudio
-except ImportError:
-    torchaudio = None
+except Exception:  # broken installs (missing native libs, ABI mismatch) should
+    torchaudio = None  # degrade to the HuggingFace path, not crash the import
 from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
 
 from whisperx.audio import SAMPLE_RATE, load_audio
@@ -40,9 +40,9 @@ DEFAULT_ALIGN_MODELS_TORCH = {
     "it": "VOXPOPULI_ASR_BASE_10K_IT",
 }
 
-# torchaudio.pipelines 模型在 Hugging Face 上的等价 checkpoint。
-# torchaudio 无 Linux aarch64 wheel（昇腾/鲲鹏 ARM 等平台装不上），
-# 此时可用这些 HF 模型兜底加载对齐模型，使 forced alignment 仍可用。
+# Hugging Face equivalents of the torchaudio.pipelines checkpoints.
+# torchaudio has no Linux aarch64 wheels (Ascend/Kunpeng ARM etc. cannot install
+# it), so fall back to these HF models to keep forced alignment available.
 TORCHAUDIO_PIPELINE_TO_HF = {
     "WAV2VEC2_ASR_BASE_960H": "facebook/wav2vec2-base-960h",
     "VOXPOPULI_ASR_BASE_10K_FR": "facebook/wav2vec2-base-10k-voxpopuli-fr",
@@ -111,7 +111,8 @@ def load_align_model(language_code: str, device: str, model_name: Optional[str] 
         labels = bundle.get_labels()
         align_dictionary = {c.lower(): i for i, c in enumerate(labels)}
     else:
-        # torchaudio 不可用时，将 torchaudio.pipelines 模型名兜底到 HF 等价 checkpoint
+        # When torchaudio is unavailable, map torchaudio.pipelines model names
+        # to their equivalent HF checkpoints.
         if torchaudio is None and model_name in TORCHAUDIO_PIPELINE_TO_HF:
             model_name = TORCHAUDIO_PIPELINE_TO_HF[model_name]
         try:


### PR DESCRIPTION
## Problem

`torchaudio` is a hard dependency of whisperX, but PyTorch publishes no Linux
aarch64 wheels for torchaudio. On Ascend NPU / Kunpeng ARM servers (whose torch
is version-decoupled from upstream PyTorch), `pip install whisperx` fails
outright, and even a source install can't import `whisperx.alignment` because
`import torchaudio` sits at module top-level.

## Change

Make torchaudio optional while keeping behavior unchanged when it *is* available:

- Guard `import torchaudio` with `try/except ImportError`, so alignment imports without it.
- Add `TORCHAUDIO_PIPELINE_TO_HF`, mapping the five `torchaudio.pipelines` align
  models to their equivalent Hugging Face checkpoints (e.g. `WAV2VEC2_ASR_BASE_960H`
  -> `facebook/wav2vec2-base-960h`). When torchaudio is absent, the default
  en/fr/de/es/it models fall back to these HF checkpoints.
- Move `torchaudio` from `dependencies` to an optional `align-torch` extra in
  `pyproject.toml` (only needed for the torchaudio.pipelines path).

## Verification

On an Ascend 910B / aarch64 container with **no torchaudio installed**
(torch 2.14.0a0 + torch_npu):

- `import whisperx.alignment` succeeds; module-level `torchaudio` is `None`.
- `TORCHAUDIO_PIPELINE_TO_HF` maps all 5 default torch models to `facebook/...` checkpoints.
- All 36 HF-default languages are unaffected.

Added `tests/test_align_model_fallback.py` to guard the mapping against regressions.