### PR TITLE
feat: add batch interleaving and cold start resolution 

### DIFF
--- a/whisperx/__main__.py
+++ b/whisperx/__main__.py
@@ -77,6 +77,7 @@ def cli():
     parser.add_argument("--hf_token", type=str, default=None, help="Hugging Face Access Token to access PyAnnote gated models")
 
     parser.add_argument("--print_progress", type=str2bool, default = False, help = "if True, progress will be printed in transcribe() and align() methods.")
+    parser.add_argument("--redo", action="store_true", help="Re-run the first batch of streams with wrap-around context")
     parser.add_argument("--version", "-V", action="version", version=f"%(prog)s {importlib.metadata.version('whisperx')}",help="Show whisperx version information and exit")
     parser.add_argument("--python-version", "-P", action="version", version=f"Python {platform.python_version()} ({platform.python_implementation()})",help="Show python version information and exit")
     # fmt: on

--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import List, Optional, Union
 from dataclasses import replace
 
@@ -40,28 +41,46 @@ class WhisperModel(faster_whisper.WhisperModel):
         tokenizer: Tokenizer,
         options: TranscriptionOptions,
         encoder_output=None,
+        previous_batch_context_tokens: List[List[int]] = None,
     ):
         batch_size = features.shape[0]
-        all_tokens = []
-        prompt_reset_since = 0
+        if previous_batch_context_tokens is None:
+            previous_batch_context_tokens = [[] for _ in range(batch_size)]
+
+        initial_prompt_tokens = []
         if options.initial_prompt is not None:
             initial_prompt = " " + options.initial_prompt.strip()
             initial_prompt_tokens = tokenizer.encode(initial_prompt)
-            all_tokens.extend(initial_prompt_tokens)
-        previous_tokens = all_tokens[prompt_reset_since:]
-        prompt = self.get_prompt(
-            tokenizer,
-            previous_tokens,
-            without_timestamps=options.without_timestamps,
-            prefix=options.prefix,
-            hotwords=options.hotwords
-        )
+
+        batch_tokens = []
+        for i in range(batch_size):
+            all_tokens = list(initial_prompt_tokens)
+            if i < len(previous_batch_context_tokens):
+                ctx = previous_batch_context_tokens[i]
+                if ctx:
+                    available = 224 - len(all_tokens)
+                    if available > 0:
+                        ctx_trimmed = ctx[-available:] if len(ctx) > available else ctx
+                        all_tokens.extend(ctx_trimmed)
+            batch_tokens.append(all_tokens)
+
+        max_batch_tokens = max([len(t) for t in batch_tokens] + [0])
+
+        prompts = [
+            self.get_prompt(
+                tokenizer,
+                [tokenizer.eot] * (max_batch_tokens - len(t)) + t,
+                without_timestamps=options.without_timestamps,
+                prefix=options.prefix,
+                hotwords=options.hotwords
+            ) for t in batch_tokens
+        ]
 
         encoder_output = self.encode(features)
-        
+
         result = self.model.generate(
                 encoder_output,
-                [prompt] * batch_size,
+                prompts,
                 beam_size=options.beam_size,
                 patience=options.patience,
                 length_penalty=options.length_penalty,
@@ -72,7 +91,7 @@ class WhisperModel(faster_whisper.WhisperModel):
                 repetition_penalty=options.repetition_penalty,
                 return_scores=True,
             )
-
+        
         tokens_batch = [x.sequences_ids[0] for x in result]
 
         avg_logprobs = []
@@ -90,7 +109,15 @@ class WhisperModel(faster_whisper.WhisperModel):
 
         text = decode_batch(tokens_batch)
 
-        return {'text': text, 'avg_logprob': avg_logprobs}
+        filtered_tokens = [[t for t in tk if t < tokenizer.eot] for tk in tokens_batch]
+        context_tokens_len = [len(t) for t in batch_tokens]
+
+        return {
+            'text': text,
+            'avg_logprob': avg_logprobs,
+            'tokens': filtered_tokens,
+            'context_tokens_len': context_tokens_len,
+        }
 
     def encode(self, features: np.ndarray) -> ctranslate2.StorageView:
         # When the model is running on multiple GPUs, the encoder output should be moved
@@ -149,6 +176,12 @@ class FasterWhisperPipeline(Pipeline):
         super(Pipeline, self).__init__()
         self.vad_model = vad
         self._vad_params = vad_params
+        self.previous_batch_context_tokens = []
+        self.last_segment_tokens_per_stream = []
+        self.stream_segment_indices = []
+        self.segment_output_tokens = {}  # Track output tokens per stream:segment for verification
+        self.batch_counter = 0  # Track batch boundaries
+        self._use_redo_context = False  # Internal flag: set True by transcribe() when --redo is active
 
     def _sanitize_parameters(self, **kwargs):
         preprocess_kwargs = {}
@@ -167,7 +200,35 @@ class FasterWhisperPipeline(Pipeline):
         return {'inputs': features}
 
     def _forward(self, model_inputs):
-        outputs = self.model.generate_segment_batched(model_inputs['inputs'], self.tokenizer, self.options)
+        current_batch_size = model_inputs['inputs'].shape[0]
+        valid_contexts = self.previous_batch_context_tokens[:current_batch_size]
+
+        self.batch_counter += 1
+
+        outputs = self.model.generate_segment_batched(
+            model_inputs['inputs'],
+            self.tokenizer,
+            self.options,
+            previous_batch_context_tokens=valid_contexts,
+        )
+
+        # Rolling context update: accumulate output tokens per stream (only when redo is active)
+        if self._use_redo_context:
+            initial_prompt_length = 0
+            if self.options.initial_prompt is not None:
+                initial_prompt = " " + self.options.initial_prompt.strip()
+                initial_prompt_length = len(self.tokenizer.encode(initial_prompt))
+
+            max_context_window = max(0, 224 - initial_prompt_length)
+
+            for i in range(current_batch_size):
+                if i < len(self.previous_batch_context_tokens):
+                    tokens = outputs['tokens'][i]
+                    self.last_segment_tokens_per_stream[i] = tokens
+                    self.previous_batch_context_tokens[i].extend(tokens)
+                    self.previous_batch_context_tokens[i] = self.previous_batch_context_tokens[i][-max_context_window:]
+                    self.stream_segment_indices[i] += 1
+
         return outputs
 
     def postprocess(self, model_outputs):
@@ -206,9 +267,24 @@ class FasterWhisperPipeline(Pipeline):
         combined_progress=False,
         verbose=False,
         progress_callback: ProgressCallback = None,
+        redo_first_batch: bool = False,
     ) -> TranscriptionResult:
+
         if isinstance(audio, str):
             audio = load_audio(audio)
+        
+        batch_size = batch_size or self._batch_size
+        # Initialize context for each stream. 
+        # We have 'batch_size' concurrent streams.
+        if batch_size is None or batch_size < 1:
+            batch_size = 1
+
+        # Gate all redo-context machinery on the redo flag
+        self._use_redo_context = redo_first_batch and batch_size > 1
+
+        self.previous_batch_context_tokens = [[] for _ in range(batch_size)]
+        self.last_segment_tokens_per_stream = [[] for _ in range(batch_size)]
+        self.stream_segment_indices = [0 for _ in range(batch_size)]
 
         def data(audio, segments):
             for seg in segments:
@@ -262,8 +338,46 @@ class FasterWhisperPipeline(Pipeline):
             self.options = replace(self.options, suppress_tokens=new_suppressed_tokens)
 
         segments: List[SingleSegment] = []
-        batch_size = batch_size or self._batch_size
         total_segments = len(vad_segments)
+
+        # Warn if batch_size is large relative to the number of VAD chunks
+        if batch_size >= total_segments:
+            warnings.warn(
+                f"batch_size ({batch_size}) is >= total VAD chunks ({total_segments}). "
+                "Each stream will receive ≤1 segment so rolling context has no effect. "
+                "Consider reducing --batch_size.",
+                UserWarning,
+                stacklevel=2,
+            )
+        elif batch_size >= total_segments // 2:
+            warnings.warn(
+                f"batch_size ({batch_size}) is more than half the total VAD chunks ({total_segments}). "
+                "Streams will have very few segments; consider reducing --batch_size for better context.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        if self._use_redo_context:
+            num_streams = batch_size
+            # Distribute segments into streams
+            k, m = divmod(len(vad_segments), num_streams)
+            stream_segments = []
+            start_idx = 0
+            for i in range(num_streams):
+                part_len = k + 1 if i < m else k
+                stream_segments.append(vad_segments[start_idx : start_idx + part_len])
+                start_idx += part_len
+
+            # Interleave streams so each batch contains one segment per stream
+            interleaved_segments = []
+            max_len = max(len(s) for s in stream_segments)
+            for i in range(max_len):
+                for stream in stream_segments:
+                    if i < len(stream):
+                        interleaved_segments.append(stream[i])
+
+            vad_segments = interleaved_segments
+
         for idx, out in enumerate(self.__call__(data(audio, vad_segments), batch_size=batch_size, num_workers=num_workers)):
             if print_progress:
                 base_progress = ((idx + 1) / total_segments) * 100
@@ -271,21 +385,63 @@ class FasterWhisperPipeline(Pipeline):
                 print(f"Progress: {percent_complete:.2f}%...")
             if progress_callback is not None:
                 progress_callback(((idx + 1) / total_segments) * 100)
+
             text = out['text']
             avg_logprob = out['avg_logprob']
-            if batch_size in [0, 1, None]:
+            if isinstance(text, list):
                 text = text[0]
+            if isinstance(avg_logprob, list):
                 avg_logprob = avg_logprob[0]
+            
             if verbose:
                 print(f"Transcript: [{round(vad_segments[idx]['start'], 3)} --> {round(vad_segments[idx]['end'], 3)}] {text}")
             segments.append(
                 {
-                    "text": text,
-                    "start": round(vad_segments[idx]['start'], 3),
-                    "end": round(vad_segments[idx]['end'], 3),
-                    "avg_logprob": avg_logprob,
+                "text": text,
+                "start": round(vad_segments[idx]['start'], 3),
+                "end": round(vad_segments[idx]['end'], 3),
+                "avg_logprob": avg_logprob,
+                # "context_tokens_len": out['context_tokens_len'][0] if isinstance(out['context_tokens_len'], list) else out['context_tokens_len'],
+                # "stream_id": out['stream_ids'][0] if isinstance(out['stream_ids'], list) else out['stream_ids'],
+                # "stream_segment_idx": out['stream_segment_indices'][0] if isinstance(out['stream_segment_indices'], list) else out['stream_segment_indices'],
+                # "is_redone": False,
                 }
             )
+
+
+        if redo_first_batch and batch_size > 1:
+            # After first pass, self.previous_batch_context_tokens contains accumulated context
+            # from multiple segments of each stream. Use this for proper wrap-around.
+            accumulated_context = [list(t) for t in self.previous_batch_context_tokens[:batch_size]]
+            # Prepare context for the wrap-around re-run:
+            # Stream 0 stays empty (very start of audio)
+            # Stream i gets context from Stream i-1's accumulated context
+            new_rerun_context = [[] for _ in range(batch_size)]
+            for i in range(1, batch_size):
+                new_rerun_context[i] = accumulated_context[i - 1]
+            # Temporarily overwrite previous_batch_context_tokens for the re-run
+            self.previous_batch_context_tokens = new_rerun_context
+            first_batch_segments = vad_segments[:batch_size]
+
+            # Reset last_segment_tokens_per_stream and segment index counter for redo pass
+            self.last_segment_tokens_per_stream = [[] for _ in range(batch_size)]
+            self.stream_segment_indices = [0 for _ in range(batch_size)]
+
+            # Runs the model again just on 'first_batch_segments'
+            for i, out in enumerate(self.__call__(data(audio, first_batch_segments), batch_size=batch_size, num_workers=num_workers)):
+                text = out['text']
+                # Overwrite the existing text with the new wrap-around text
+                if isinstance(text, list):
+                    text = text[0]
+                if verbose:
+                    logger.info(f"[REDO] Segment {i} redo:     {text[:80]}...")
+                segments[i]['text'] = text
+                # segments[i]['is_redone'] = True
+                # segments[i]['context_tokens_len'] = out['context_tokens_len'][0] if isinstance(out['context_tokens_len'], list) else out['context_tokens_len']
+                # segments[i]['stream_id'] = out['stream_ids'][0] if isinstance(out['stream_ids'], list) else out['stream_ids']
+                # segments[i]['stream_segment_idx'] = out['stream_segment_indices'][0] if isinstance(out['stream_segment_indices'], list) else out['stream_segment_indices']
+        # Sort segments by start time to restore original order
+        segments.sort(key=lambda x: x['start'])
 
         # revert the tokenizer if multilingual inference is enabled
         if self.preset_language is None:
@@ -375,7 +531,7 @@ def load_model(
         "length_penalty": 1,
         "repetition_penalty": 1,
         "no_repeat_ngram_size": 0,
-        "temperatures": [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+        "temperatures": [0.0,0.2,0.4,0.6,0.8,1.0],
         "compression_ratio_threshold": 2.4,
         "log_prob_threshold": -1.0,
         "no_speech_threshold": 0.6,

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -63,6 +63,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
     diarize_model_name: str = args.pop("diarize_model")
     print_progress: bool = args.pop("print_progress")
     return_speaker_embeddings: bool = args.pop("speaker_embeddings")
+    redo_first_batch: bool = args.pop("redo", False)
 
     if return_speaker_embeddings and not diarize:
         warnings.warn("--speaker_embeddings has no effect without --diarize")
@@ -154,6 +155,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
             chunk_size=chunk_size,
             print_progress=print_progress,
             verbose=verbose,
+            redo_first_batch=redo_first_batch,
         )
         results.append((result, audio_path))
 


### PR DESCRIPTION
Summary
Adds a new opt-in flag that improve transcription coherence when using batched inference — zero impact on default behaviour.

Changes
whisperx/asr.py

generate_segment_batched: per-stream prompt injection using rolling token context
FasterWhisperPipeline._forward: accumulates output tokens per stream after each batch
FasterWhisperPipeline.transcribe: batch interleaving of VAD segments across N streams; wrap-around redo of first batch; final sort to restore chronological order


whisperx/transcribe.py: wires --redo through transcribe_task

whisperx/__main__.py: adds --redo CLI flag

Usage

# redo (interleaving, rolling context and wrap-around context on first batch)
e.g whisperx audio.mp3 --model large-v2 --batch_size 8  --redo


New flag defaults to False. A user running whisperX without this flag gets identical behaviour to upstream — no code paths are entered, no performance impact.

Warning added:
if batch size is similar or equal to the total number chunks, user is advised to reduce batch size.