### PR TITLE
fix(cli): write the transcribed language instead of the --language default

### DIFF
--- a/tests/test_cli_output_language.py
+++ b/tests/test_cli_output_language.py
@@ -1,0 +1,78 @@
+"""Test that the CLI reports the transcribed language rather than the --language default."""
+
+import json
+import sys
+from unittest.mock import patch
+
+import numpy as np
+
+import whisperx.transcribe as transcribe_module
+from whisperx.__main__ import cli
+
+SEGMENTS = [{"start": 0.0, "end": 2.0, "text": "今日はいい天気"}]
+WORDS = [
+    {"word": "今日", "start": 0.0, "end": 0.6, "score": 0.9},
+    {"word": "は", "start": 0.6, "end": 0.9, "score": 0.9},
+    {"word": "いい天気", "start": 0.9, "end": 2.0, "score": 0.9},
+]
+
+
+class StubModel:
+    """Stands in for the faster-whisper pipeline and reports a fixed language."""
+
+    def __init__(self, language):
+        self.language = language
+
+    def transcribe(self, *args, **kwargs):
+        return {"segments": [dict(seg) for seg in SEGMENTS], "language": self.language}
+
+
+def stub_align(transcript, *args, **kwargs):
+    """Mimic align(), which returns no language key."""
+    return {
+        "segments": [dict(transcript[0], words=[dict(word) for word in WORDS])],
+        "word_segments": [dict(word) for word in WORDS],
+    }
+
+
+def run_cli(tmp_path, extra_args, detected="ja"):
+    """Run the real CLI over one stub audio file and return its JSON and SRT output."""
+    audio = tmp_path / "sample.wav"
+    audio.write_bytes(b"\0")
+    argv = ["whisperx", str(audio), "--output_dir", str(tmp_path), "--verbose", "False"]
+
+    with (
+        patch.object(transcribe_module, "load_model", lambda *a, **k: StubModel(detected)),
+        patch.object(transcribe_module, "load_audio", lambda *a, **k: np.zeros(16000, dtype=np.float32)),
+        patch.object(transcribe_module, "load_align_model", lambda *a, **k: (object(), {"language": detected})),
+        patch.object(transcribe_module, "align", stub_align),
+        patch.object(sys, "argv", argv + extra_args),
+    ):
+        cli()
+
+    result = json.loads(audio.with_suffix(".json").read_text(encoding="utf-8"))
+    srt = audio.with_suffix(".srt").read_text(encoding="utf-8")
+    return result, srt
+
+
+class TestCLIOutputLanguage:
+    def test_detected_language_is_written(self, tmp_path):
+        result, _ = run_cli(tmp_path, [])
+        assert result["language"] == "ja"
+
+    def test_detected_ja_joins_words_without_spaces(self, tmp_path):
+        """Regression for #248: auto-detected ja must not gain spaces between words."""
+        _, srt = run_cli(tmp_path, [])
+        assert srt.strip().splitlines()[-1] == "今日はいい天気"
+
+    def test_detected_language_is_written_without_alignment(self, tmp_path):
+        result, _ = run_cli(tmp_path, ["--no_align"])
+        assert result["language"] == "ja"
+
+    def test_explicit_language_is_written(self, tmp_path):
+        result, _ = run_cli(tmp_path, ["--language", "ja"])
+        assert result["language"] == "ja"
+
+    def test_english_keeps_spaces(self, tmp_path):
+        _, srt = run_cli(tmp_path, [], detected="en")
+        assert srt.strip().splitlines()[-1] == "今日 は いい天気"

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -187,6 +187,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
                         result["language"], device, model_dir=model_dir, model_cache_only=model_cache_only
                     )
                 logger.info("Performing alignment...")
+                transcribed_language = result.get("language", align_language)
                 result: AlignedTranscriptionResult = align(
                     result["segments"],
                     align_model,
@@ -197,6 +198,9 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
                     return_char_alignments=return_char_alignments,
                     print_progress=print_progress,
                 )
+                # align() returns no language key, and the writers need one to
+                # pick the word separator for ja and zh.
+                result["language"] = transcribed_language
 
             results.append((result, audio_path))
 
@@ -234,5 +238,5 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
             results.append((result, input_audio_path))
     # >> Write
     for result, audio_path in results:
-        result["language"] = align_language
+        result.setdefault("language", align_language)
         writer(result, audio_path, writer_args)


### PR DESCRIPTION
`transcribe_task` ends with `result["language"] = align_language`, and `align_language` falls back to `"en"` whenever `--language` is not passed. On the default auto-detect path every output file gets stamped `"language": "en"` no matter what the ASR actually detected.

That is worse than a cosmetic JSON field. `SubtitlesWriter` picks its word separator from `result["language"]`, so auto-detected Japanese and Chinese subtitles come out with a space between every word. That is the exact bug the line was added to fix in f505702 (#248, #310).

Reproduced with `load_model`, `align` and `load_audio` stubbed so the ASR reports `ja`:

| | `"language"` in JSON | SRT cue |
|---|---|---|
| before | `"en"` | `今日 は いい天気` |
| after | `"ja"` | `今日はいい天気` |

The line exists because `align()` returns an `AlignedTranscriptionResult`, which has no `language` key, so the detected value is dropped at the align step. The fix carries it across `align()` and falls back to `align_language` only when nothing reported one.

Passing `--language ja` behaves exactly as before, and English output is byte for byte unchanged. I also checked `--no_align`, `--task translate`, `--diarize`, multiple input files, empty segments, and every `--output_format`. Only the language label changes, and only where it was wrong.

Five tests added in `tests/test_cli_output_language.py`. Three fail without the patch, two guard the paths that already worked.