### PR TITLE
feat: add batch interleaving and interleaved context

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,8 @@ This repository provides fast automatic speech recognition (70x realtime with la
 
 - 1st place at [Ego4d transcription challenge](https://eval.ai/web/challenges/challenge-page/1637/leaderboard/3931/WER) 🏆
 - _WhisperX_ accepted at INTERSPEECH 2023
-- v3 transcript segment-per-sentence: using nltk sent_tokenize for better subtitlting & better diarization
 - v3 released, 70x speed-up open-sourced. Using batched whisper with [faster-whisper](https://github.com/guillaumekln/faster-whisper) backend!
-- v2 released, code cleanup, imports whisper library VAD filtering is now turned on by default, as in the paper.
-- Paper drop🎓👨‍🏫! Please see our [ArxiV preprint](https://arxiv.org/abs/2303.00747) for benchmarking and details of WhisperX. We also introduce more efficient batch inference resulting in large-v2 with \*60-70x REAL TIME speed.
+- Context-Aware Batching Released 2026: We successfully enable condition_on_previous_context within our batched transcription framework, improving punctuation and proper noun adherence. See our [ArXiv preprint](https://arxiv.org/abs/2608.31170).
 
 <h2 align="left" id="setup">Setup ⚙️</h2>
 
@@ -139,9 +137,18 @@ To label the transcript with speaker ID's (set number of speakers if known e.g. 
 
     whisperx path/to/audio.wav --model large-v2 --diarize --highlight_words True
 
+To maintain continuous context (ideal for technical language / punctuation), set interleaved_context=True:
+
+    whisperx path/to/audio.wav --model large-v2 --interleaved_context
+
 To run on CPU instead of GPU (and for running on Mac OS X):
 
     whisperx path/to/audio.wav --compute_type int8 --device cpu
+
+For conditioning on previous context (This allows context to be passed from the previous segment, leading to better results on long audio):
+
+    whisperx path/to/audio.wav --model large-v2 --interleaved_context
+
 
 ### Other languages
 
@@ -178,7 +185,8 @@ model = whisperx.load_model("large-v2", device, compute_type=compute_type)
 # model = whisperx.load_model("large-v2", device, compute_type=compute_type, download_root=model_dir)
 
 audio = whisperx.load_audio(audio_file)
-result = model.transcribe(audio, batch_size=batch_size)
+
+result = model.transcribe(audio, batch_size=batch_size, interleaved_context=True)
 print(result["segments"]) # before alignment
 
 # delete model if low on GPU resources
@@ -306,5 +314,16 @@ If you use this in your research, please cite the paper:
   author={Bain, Max and Huh, Jaesung and Han, Tengda and Zisserman, Andrew},
   journal={INTERSPEECH 2023},
   year={2023}
+}
+```
+
+Please also cite the paper below if you enabled interleaved context:
+
+```bibtex
+@article{bain2026context,
+  title={Context-Aware Interleaved Batching for WhisperX},
+  author={Bain, Carlos and Bain, Max},
+  journal={arXiv preprint arXiv:2608.31170v1},
+  year={2026}
 }
 ```

--- a/whisperx/__main__.py
+++ b/whisperx/__main__.py
@@ -77,6 +77,7 @@ def cli():
     parser.add_argument("--hf_token", type=str, default=None, help="Hugging Face Access Token to access PyAnnote gated models")
 
     parser.add_argument("--print_progress", type=str2bool, default = False, help = "if True, progress will be printed in transcribe() and align() methods.")
+    parser.add_argument("--interleaved_context", action="store_true", help="Enable interleaved context: re-run the first batch of streams with wrap-around context")
     parser.add_argument("--version", "-V", action="version", version=f"%(prog)s {importlib.metadata.version('whisperx')}",help="Show whisperx version information and exit")
     parser.add_argument("--python-version", "-P", action="version", version=f"Python {platform.python_version()} ({platform.python_implementation()})",help="Show python version information and exit")
     # fmt: on

--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import List, Optional, Union
 from dataclasses import replace
 
@@ -40,28 +41,46 @@ class WhisperModel(faster_whisper.WhisperModel):
         tokenizer: Tokenizer,
         options: TranscriptionOptions,
         encoder_output=None,
+        previous_batch_context_tokens: List[List[int]] = None,
     ):
         batch_size = features.shape[0]
-        all_tokens = []
-        prompt_reset_since = 0
+        if previous_batch_context_tokens is None:
+            previous_batch_context_tokens = [[] for _ in range(batch_size)]
+
+        initial_prompt_tokens = []
         if options.initial_prompt is not None:
             initial_prompt = " " + options.initial_prompt.strip()
             initial_prompt_tokens = tokenizer.encode(initial_prompt)
-            all_tokens.extend(initial_prompt_tokens)
-        previous_tokens = all_tokens[prompt_reset_since:]
-        prompt = self.get_prompt(
-            tokenizer,
-            previous_tokens,
-            without_timestamps=options.without_timestamps,
-            prefix=options.prefix,
-            hotwords=options.hotwords
-        )
+
+        batch_tokens = []
+        for i in range(batch_size):
+            all_tokens = list(initial_prompt_tokens)
+            if i < len(previous_batch_context_tokens):
+                ctx = previous_batch_context_tokens[i]
+                if ctx:
+                    available = 224 - len(all_tokens)
+                    if available > 0:
+                        ctx_trimmed = ctx[-available:] if len(ctx) > available else ctx
+                        all_tokens.extend(ctx_trimmed)
+            batch_tokens.append(all_tokens)
+
+        max_batch_tokens = max([len(t) for t in batch_tokens] + [0])
+
+        prompts = [
+            self.get_prompt(
+                tokenizer,
+                [tokenizer.eot] * (max_batch_tokens - len(t)) + t,
+                without_timestamps=options.without_timestamps,
+                prefix=options.prefix,
+                hotwords=options.hotwords
+            ) for t in batch_tokens
+        ]
 
         encoder_output = self.encode(features)
-        
+
         result = self.model.generate(
                 encoder_output,
-                [prompt] * batch_size,
+                prompts,
                 beam_size=options.beam_size,
                 patience=options.patience,
                 length_penalty=options.length_penalty,
@@ -72,7 +91,7 @@ class WhisperModel(faster_whisper.WhisperModel):
                 repetition_penalty=options.repetition_penalty,
                 return_scores=True,
             )
-
+        
         tokens_batch = [x.sequences_ids[0] for x in result]
 
         avg_logprobs = []
@@ -85,12 +104,19 @@ class WhisperModel(faster_whisper.WhisperModel):
             res = []
             for tk in tokens:
                 res.append([token for token in tk if token < tokenizer.eot])
-            # text_tokens = [token for token in tokens if token < self.eot]
             return tokenizer.tokenizer.decode_batch(res)
 
         text = decode_batch(tokens_batch)
 
-        return {'text': text, 'avg_logprob': avg_logprobs}
+        filtered_tokens = [[t for t in tk if t < tokenizer.eot] for tk in tokens_batch]
+        context_tokens_len = [len(t) for t in batch_tokens]
+
+        return {
+            'text': text,
+            'avg_logprob': avg_logprobs,
+            'tokens': filtered_tokens,
+            'context_tokens_len': context_tokens_len,
+        }
 
     def encode(self, features: np.ndarray) -> ctranslate2.StorageView:
         # When the model is running on multiple GPUs, the encoder output should be moved
@@ -149,6 +175,12 @@ class FasterWhisperPipeline(Pipeline):
         super(Pipeline, self).__init__()
         self.vad_model = vad
         self._vad_params = vad_params
+        self.previous_batch_context_tokens = []
+        self.last_segment_tokens_per_stream = []
+        self.stream_segment_indices = []
+        self.segment_output_tokens = {}  # Track output tokens per stream:segment for verification
+        self.batch_counter = 0  # Track batch boundaries
+        self._use_interleaved_context = False  # Internal flag: set True by transcribe() when interleaved context is active
 
     def _sanitize_parameters(self, **kwargs):
         preprocess_kwargs = {}
@@ -167,7 +199,35 @@ class FasterWhisperPipeline(Pipeline):
         return {'inputs': features}
 
     def _forward(self, model_inputs):
-        outputs = self.model.generate_segment_batched(model_inputs['inputs'], self.tokenizer, self.options)
+        current_batch_size = model_inputs['inputs'].shape[0]
+        valid_contexts = self.previous_batch_context_tokens[:current_batch_size]
+
+        self.batch_counter += 1
+
+        outputs = self.model.generate_segment_batched(
+            model_inputs['inputs'],
+            self.tokenizer,
+            self.options,
+            previous_batch_context_tokens=valid_contexts,
+        )
+
+        # Rolling context update: accumulate output tokens per stream (only when interleaved context is active)
+        if self._use_interleaved_context:
+            initial_prompt_length = 0
+            if self.options.initial_prompt is not None:
+                initial_prompt = " " + self.options.initial_prompt.strip()
+                initial_prompt_length = len(self.tokenizer.encode(initial_prompt))
+
+            max_context_window = max(0, 224 - initial_prompt_length)
+
+            for i in range(current_batch_size):
+                if i < len(self.previous_batch_context_tokens):
+                    tokens = outputs['tokens'][i]
+                    self.last_segment_tokens_per_stream[i] = tokens
+                    self.previous_batch_context_tokens[i].extend(tokens)
+                    self.previous_batch_context_tokens[i] = self.previous_batch_context_tokens[i][-max_context_window:]
+                    self.stream_segment_indices[i] += 1
+
         return outputs
 
     def postprocess(self, model_outputs):
@@ -206,9 +266,24 @@ class FasterWhisperPipeline(Pipeline):
         combined_progress=False,
         verbose=False,
         progress_callback: ProgressCallback = None,
+        interleaved_context: bool = False,
     ) -> TranscriptionResult:
+
         if isinstance(audio, str):
             audio = load_audio(audio)
+        
+        batch_size = batch_size or self._batch_size
+        # Initialize context for each stream. 
+        # We have 'batch_size' concurrent streams.
+        if batch_size is None or batch_size < 1:
+            batch_size = 1
+
+        # Gate all interleaved-context machinery on the interleaved_context flag
+        self._use_interleaved_context = interleaved_context and batch_size > 1
+
+        self.previous_batch_context_tokens = [[] for _ in range(batch_size)]
+        self.last_segment_tokens_per_stream = [[] for _ in range(batch_size)]
+        self.stream_segment_indices = [0 for _ in range(batch_size)]
 
         def data(audio, segments):
             for seg in segments:
@@ -262,8 +337,46 @@ class FasterWhisperPipeline(Pipeline):
             self.options = replace(self.options, suppress_tokens=new_suppressed_tokens)
 
         segments: List[SingleSegment] = []
-        batch_size = batch_size or self._batch_size
         total_segments = len(vad_segments)
+
+        # Warn if batch_size is large relative to the number of VAD chunks
+        if batch_size >= total_segments:
+            warnings.warn(
+                f"batch_size ({batch_size}) is >= total VAD chunks ({total_segments}). "
+                "Each stream will receive ≤1 segment so rolling context has no effect. "
+                "Consider reducing --batch_size.",
+                UserWarning,
+                stacklevel=2,
+            )
+        elif batch_size >= total_segments // 2:
+            warnings.warn(
+                f"batch_size ({batch_size}) is more than half the total VAD chunks ({total_segments}). "
+                "Streams will have very few segments; consider reducing --batch_size for better context.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        if self._use_interleaved_context:
+            num_streams = batch_size
+            # Distribute segments into streams
+            k, m = divmod(len(vad_segments), num_streams)
+            stream_segments = []
+            start_idx = 0
+            for i in range(num_streams):
+                part_len = k + 1 if i < m else k
+                stream_segments.append(vad_segments[start_idx : start_idx + part_len])
+                start_idx += part_len
+
+            # Interleave streams so each batch contains one segment per stream
+            interleaved_segments = []
+            max_len = max(len(s) for s in stream_segments)
+            for i in range(max_len):
+                for stream in stream_segments:
+                    if i < len(stream):
+                        interleaved_segments.append(stream[i])
+
+            vad_segments = interleaved_segments
+
         for idx, out in enumerate(self.__call__(data(audio, vad_segments), batch_size=batch_size, num_workers=num_workers)):
             if print_progress:
                 base_progress = ((idx + 1) / total_segments) * 100
@@ -271,21 +384,55 @@ class FasterWhisperPipeline(Pipeline):
                 print(f"Progress: {percent_complete:.2f}%...")
             if progress_callback is not None:
                 progress_callback(((idx + 1) / total_segments) * 100)
+
             text = out['text']
             avg_logprob = out['avg_logprob']
-            if batch_size in [0, 1, None]:
+            if isinstance(text, list):
                 text = text[0]
+            if isinstance(avg_logprob, list):
                 avg_logprob = avg_logprob[0]
+            
             if verbose:
                 print(f"Transcript: [{round(vad_segments[idx]['start'], 3)} --> {round(vad_segments[idx]['end'], 3)}] {text}")
             segments.append(
                 {
-                    "text": text,
-                    "start": round(vad_segments[idx]['start'], 3),
-                    "end": round(vad_segments[idx]['end'], 3),
-                    "avg_logprob": avg_logprob,
+                "text": text,
+                "start": round(vad_segments[idx]['start'], 3),
+                "end": round(vad_segments[idx]['end'], 3),
+                "avg_logprob": avg_logprob,
                 }
             )
+
+
+        if interleaved_context and batch_size > 1:
+            # After first pass, self.previous_batch_context_tokens contains accumulated context
+            # from multiple segments of each stream. Use this for proper wrap-around.
+            accumulated_context = [list(t) for t in self.previous_batch_context_tokens[:batch_size]]
+            # Prepare context for the wrap-around re-run:
+            # Stream 0 stays empty (very start of audio)
+            # Stream i gets context from Stream i-1's accumulated context
+            new_rerun_context = [[] for _ in range(batch_size)]
+            for i in range(1, batch_size):
+                new_rerun_context[i] = accumulated_context[i - 1]
+            # Temporarily overwrite previous_batch_context_tokens for the re-run
+            self.previous_batch_context_tokens = new_rerun_context
+            first_batch_segments = vad_segments[:batch_size]
+
+            # Reset last_segment_tokens_per_stream and segment index counter for interleaved context pass
+            self.last_segment_tokens_per_stream = [[] for _ in range(batch_size)]
+            self.stream_segment_indices = [0 for _ in range(batch_size)]
+
+            # Runs the model again just on 'first_batch_segments'
+            for i, out in enumerate(self.__call__(data(audio, first_batch_segments), batch_size=batch_size, num_workers=num_workers)):
+                text = out['text']
+                # Overwrite the existing text with the new wrap-around text
+                if isinstance(text, list):
+                    text = text[0]
+                if verbose:
+                    logger.info(f"[INTERLEAVED] Segment {i} context redo:     {text[:80]}...")
+                segments[i]['text'] = text
+        # Sort segments by start time to restore original order
+        segments.sort(key=lambda x: x['start'])
 
         # revert the tokenizer if multilingual inference is enabled
         if self.preset_language is None:

--- a/whisperx/transcribe.py
+++ b/whisperx/transcribe.py
@@ -63,6 +63,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
     diarize_model_name: str = args.pop("diarize_model")
     print_progress: bool = args.pop("print_progress")
     return_speaker_embeddings: bool = args.pop("speaker_embeddings")
+    interleaved_context: bool = args.pop("interleaved_context", False)
 
     if return_speaker_embeddings and not diarize:
         warnings.warn("--speaker_embeddings has no effect without --diarize")
@@ -154,6 +155,7 @@ def transcribe_task(args: dict, parser: argparse.ArgumentParser):
             chunk_size=chunk_size,
             print_progress=print_progress,
             verbose=verbose,
+            interleaved_context=interleaved_context,
         )
         results.append((result, audio_path))
 


### PR DESCRIPTION
Summary
Adds a new opt-in flag that improve transcription coherence when using batched inference — zero impact on default behaviour.

Changes

generate_segment_batched: per-stream prompt injection using rolling token context
FasterWhisperPipeline._forward: accumulates output tokens per stream after each batch
FasterWhisperPipeline.transcribe: batch interleaving of VAD segments across N streams; wrap-around redo of first batch; final sort to restore chronological order

Readme updated with flag and information + link to paper.

Usage

interleaved_context. (interleaving, rolling context and wrap-around context on first batch)
e.g whisperx audio.mp3 --model large-v2 --batch_size 8 --interleaved context

New flag defaults to False. A user running whisperX without this flag gets identical behaviour to upstream — no code paths are entered, no performance impact.

Warning added:
if batch size is similar or equal to the total number chunks, user is advised to reduce batch size.